### PR TITLE
feat(oxvg_path): add PartialEq to Path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "oxvg_path"
-version = "0.0.1"
+version = "0.0.1-beta.1"
 dependencies = [
  "bitflags 2.6.0",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ oxvg = { path = "crates/oxvg" }
 oxvg_ast = { path = "crates/oxvg_ast", version = "0.0.1-alpha.1" }
 oxvg_diagnostics = { path = "crates/oxvg_diagnostics", version = "0.0.1-alpha.1" }
 oxvg_optimiser = { path = "crates/oxvg_optimiser" }
-oxvg_path = { path = "crates/oxvg_path", version = "0.0.1" }
+oxvg_path = { path = "crates/oxvg_path", version = "0.0.1-beta.1" }
 oxvg_selectors = { path = "crates/oxvg_selectors", version = "0.0.1-alpha.1" }
 oxvg_style = { path = "crates/oxvg_style", version = "0.0.1-alpha.1" }
 oxvg_utils = { path = "crates/oxvg_utils" }

--- a/crates/oxvg_path/src/command.rs
+++ b/crates/oxvg_path/src/command.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::fmt::Write;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Data {
     /// M
     /// Move the current point to coordinate `x`, `y`. Any subsequent coordinate pair(s) are

--- a/crates/oxvg_path/src/lib.rs
+++ b/crates/oxvg_path/src/lib.rs
@@ -33,7 +33,7 @@ use std::fmt::Write;
 
 pub use crate::parser::Error;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 /// A path is a set of commands
 ///
 /// # Example


### PR DESCRIPTION
This adds `PartialEq` to `Path`, as required for `BasicShape::Path` of lightningcss