### PR TITLE
Improve usage as a library

### DIFF
--- a/crates/oxvg_ast/src/element.rs
+++ b/crates/oxvg_ast/src/element.rs
@@ -232,14 +232,14 @@ pub trait Element: Node + Features + Debug + std::hash::Hash + Eq + PartialEq {
     fn get_attribute<'a>(
         &'a self,
         name: &<<Self::Attributes<'a> as Attributes<'a>>::Attribute as Attr>::Name,
-    ) -> Option<impl Deref<Target = Self::Atom>>;
+    ) -> Option<Self::Atom>;
 
     /// Returns the value of an attribute of the element specified by a local name, only if that
     /// attribute also has no prefix
     fn get_attribute_local<'a>(
         &'a self,
         name: &<<Self::Attr as Attr>::Name as Name>::LocalName,
-    ) -> Option<impl Deref<Target = Self::Atom> + 'a>;
+    ) -> Option<Self::Atom>;
 
     /// Returns the value of an attribute of the element specified by it's local name and
     /// namespace.
@@ -249,14 +249,14 @@ pub trait Element: Node + Features + Debug + std::hash::Hash + Eq + PartialEq {
         &'a self,
         namespace: &<<<Self::Attributes<'a> as Attributes<'a>>::Attribute as Attr>::Name as Name>::Namespace,
         name: &<<<Self::Attributes<'a> as Attributes<'a>>::Attribute as Attr>::Name as Name>::LocalName,
-    ) -> Option<impl Deref<Target = Self::Atom>>;
+    ) -> Option<Self::Atom>;
 
     /// Returns a collection of the attribute names of the element.
     ///
     /// [MDN | getAttributeNames](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames)
     fn get_attribute_names(
         &self,
-    ) -> Vec<impl Deref<Target = <<Self::Attributes<'_> as Attributes<'_>>::Attribute as Attr>::Name>>;
+    ) -> Vec<<<Self::Attributes<'_> as Attributes<'_>>::Attribute as Attr>::Name>;
 
     /// Returns the attribute specified by it's qualified name.
     ///

--- a/crates/oxvg_ast/src/implementations/markup5ever.rs
+++ b/crates/oxvg_ast/src/implementations/markup5ever.rs
@@ -3,7 +3,6 @@ use std::{
     collections::VecDeque,
     fmt::Debug,
     hash::{DefaultHasher, Hash, Hasher},
-    ops::Deref,
     rc::Rc,
 };
 

--- a/crates/oxvg_ast/src/implementations/markup5ever.rs
+++ b/crates/oxvg_ast/src/implementations/markup5ever.rs
@@ -48,9 +48,6 @@ pub struct ClassList5Ever<'a> {
 #[derive(Clone)]
 pub struct Node5Ever(Rc<rcdom::Node>);
 
-#[derive(Debug)]
-pub struct Node5EverRef(Rc<Node5Ever>);
-
 #[derive(Clone)]
 pub struct Element5Ever {
     node: Node5Ever,
@@ -602,10 +599,6 @@ impl Node for Node5Ever {
     fn as_ptr_byte(&self) -> usize {
         Rc::as_ptr(&self.0) as usize
     }
-
-    // fn as_ref(&self) -> Box<dyn node::Ref> {
-    //     Box::new(Node5EverRef(Rc::new(self.clone())))
-    // }
 
     fn child_nodes_iter(&self) -> impl DoubleEndedIterator<Item = Self> {
         let children = self.0.children.borrow().clone();
@@ -1317,10 +1310,6 @@ impl Node for Element5Ever {
         self.node.as_ptr_byte()
     }
 
-    // fn as_ref(&self) -> Box<dyn node::Ref> {
-    //     self.node.as_ref()
-    // }
-
     fn child_nodes_iter(&self) -> impl DoubleEndedIterator<Item = Self::Child> {
         self.node.child_nodes().into_iter()
     }
@@ -1538,17 +1527,6 @@ impl parse::Node for Element5Ever {
             Some(element) => Ok(element),
             None => Err(anyhow::Error::new(parse::Error::NoElementInDocument)),
         }
-    }
-}
-
-impl node::Ref for Node5EverRef {
-    fn inner_as_any(&self) -> &dyn std::any::Any {
-        let inner: &Node5Ever = self.0.as_ref();
-        inner as &dyn std::any::Any
-    }
-
-    fn clone(&self) -> Box<dyn node::Ref> {
-        Box::new(Self(self.0.clone()))
     }
 }
 

--- a/crates/oxvg_ast/src/implementations/markup5ever.rs
+++ b/crates/oxvg_ast/src/implementations/markup5ever.rs
@@ -159,11 +159,13 @@ impl Attr for Attribute {
     }
 
     fn presentation(&self) -> Option<crate::style::PresentationAttr> {
-        self.name.prefix.as_ref()?;
+        if self.name.prefix.is_some() {
+            return None;
+        }
         let id = crate::style::PresentationAttrId::from(self.name.local.as_ref());
         crate::style::PresentationAttr::parse_string(
             id,
-            self.name.local.as_ref(),
+            self.value.as_ref(),
             lightningcss::stylesheet::ParserOptions::default(),
         )
         .ok()

--- a/crates/oxvg_ast/src/node.rs
+++ b/crates/oxvg_ast/src/node.rs
@@ -35,15 +35,6 @@ pub enum Type {
     DocumentFragment,
 }
 
-/// An opaque reference to [Node] that can be used in structs as `dyn` instead of `impl`
-pub trait Ref: Debug {
-    /// Upcasts the ref to `Any`
-    fn inner_as_any(&self) -> &dyn std::any::Any;
-
-    /// Creates a clone of the underlying type, usually an `Rc`
-    fn clone(&self) -> Box<dyn Ref>;
-}
-
 #[cfg(not(feature = "parse"))]
 #[cfg(not(feature = "serialize"))]
 pub trait Features {}

--- a/crates/oxvg_ast/src/node.rs
+++ b/crates/oxvg_ast/src/node.rs
@@ -63,10 +63,11 @@ pub trait Features: crate::parse::Node + crate::serialize::Node {}
 /// An XML DOM node upon which other DOM API objects are based
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/API/Node>
-pub trait Node: Clone + Debug + 'static + Features {
+pub trait Node: Clone + Debug + Features {
     type Atom: Atom;
     type Child: Node<Atom = Self::Atom>;
-    type ParentChild: Node<Atom = Self::Atom>;
+    type ParentChild: Node<Atom = Self::Atom, Parent = Self::Parent>;
+    type Parent: Node<Atom = Self::Atom, Child = Self::ParentChild>;
 
     /// Whether the underlying pointer is at the same address as the other
     fn ptr_eq(&self, other: &impl Node) -> bool;
@@ -75,7 +76,7 @@ pub trait Node: Clone + Debug + 'static + Features {
     fn as_ptr_byte(&self) -> usize;
 
     /// Get the node wrapped in an opaque reference
-    fn as_ref(&self) -> Box<dyn Ref>;
+    // fn as_ref(&self) -> Box<dyn Ref>;
 
     /// Returns an node list containing all the children of this node
     #[deprecated(note = "try use for_each_child, map_each_child, fold_each_child, etc, instead")]
@@ -170,7 +171,7 @@ pub trait Node: Clone + Debug + 'static + Features {
 
     /// Returns the processing instruction's target and data, if the node is a processing
     /// instruction
-    fn processing_instruction(&self) -> Option<(&Self::Atom, &Self::Atom)>;
+    fn processing_instruction(&self) -> Option<(Self::Atom, Self::Atom)>;
 
     /// Tries settings the value of the node if possible. If not possible, returns [None].
     ///
@@ -197,7 +198,7 @@ pub trait Node: Clone + Debug + 'static + Features {
     /// property if the top of the tree or if it doesn't participate in a tree, this returns [None]
     ///
     /// [MDN | parentNode](https://developer.mozilla.org/en-US/docs/Web/API/Node/parentNode)
-    fn parent_node(&self) -> Option<impl Node<Child = Self::ParentChild, Atom = Self::Atom>>;
+    fn parent_node(&self) -> Option<Self::Parent>;
 
     /// Changes the return value of [`Node::parent_node`] to the given node
     ///
@@ -211,10 +212,7 @@ pub trait Node: Clone + Debug + 'static + Features {
     /// using [Element], you may want to try using [`Node::insert`], [`Node::insert_before`],
     /// [`Node::insert_after`], [`Element::after`], [`Element::before`], or
     /// [`Element::prepend`]
-    fn set_parent_node(
-        &self,
-        new_parent: &impl Node<Atom = Self::Atom>,
-    ) -> Option<impl Node<Child = <Self::ParentChild as Node>::Child, Atom = Self::Atom>>;
+    fn set_parent_node(&self, new_parent: &Self::Parent) -> Option<Self::Parent>;
 
     /// Adds a node to the end of the list of children of a specified node. This will update the
     /// parent of `a_child`

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -262,10 +262,12 @@ macro_rules! define_presentation_attrs {
                     $(
                         PresentationAttr::$attr(val) => val.to_css(dest),
                     )+
-                    PresentationAttr::Unknown(unknown) => Property::Custom(CustomProperty {
-                            name: CustomPropertyName::Unknown("".into()),
-                            value: unknown.value.clone()
-                        }).value_to_css(dest),
+                    PresentationAttr::Unknown(unknown) => {
+                      Property::Custom(CustomProperty {
+                              name: CustomPropertyName::Unknown("".into()),
+                              value: unknown.value.clone()
+                          }).value_to_css(dest)
+                    },
                     PresentationAttr::Unparsed(unparsed) => Property::Custom(CustomProperty {
                             name: CustomPropertyName::Unknown("".into()),
                             value: unparsed.value.clone(),
@@ -1519,10 +1521,7 @@ impl<E: Element> ElementData<E> {
             styles.insert(
                 element.clone(),
                 ElementData {
-                    inline_style: element
-                        .get_attribute_local(&"style".into())
-                        .as_deref()
-                        .cloned(),
+                    inline_style: element.get_attribute_local(&"style".into()).clone(),
                     presentation_attrs: element
                         .attributes()
                         .into_iter()

--- a/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
+++ b/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
@@ -27,8 +27,8 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 /// Apply transformations to the path data
 pub struct ApplyTransforms {
-    transform_precision: Option<f64>,
-    apply_transforms_stroked: Option<bool>,
+    pub transform_precision: Option<f64>,
+    pub apply_transforms_stroked: Option<bool>,
 }
 
 impl<E: Element> Visitor<E> for ApplyTransforms {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_attributes.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_attributes.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CleanupAttributes {
-    newlines: Option<bool>,
-    trim: Option<bool>,
-    spaces: Option<bool>,
+    pub newlines: Option<bool>,
+    pub trim: Option<bool>,
+    pub spaces: Option<bool>,
 }
 
 impl<E: Element> Visitor<E> for CleanupAttributes {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
@@ -34,13 +34,13 @@ struct RefRename<E: Element> {
 #[serde(rename_all = "camelCase")]
 struct Options {
     #[serde(default = "default_remove")]
-    remove: bool,
+    pub remove: bool,
     #[serde(default = "default_minify")]
-    minify: bool,
-    preserve: Option<Vec<String>>,
-    preserve_prefixes: Option<Vec<String>>,
+    pub minify: bool,
+    pub preserve: Option<Vec<String>>,
+    pub preserve_prefixes: Option<Vec<String>>,
     #[serde(default = "bool::default")]
-    force: bool,
+    pub force: bool,
 }
 
 impl Default for Options {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
@@ -30,7 +30,7 @@ struct RefRename<E: Element> {
     referenced_id: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 struct Options {
     #[serde(default = "default_remove")]
@@ -41,6 +41,18 @@ struct Options {
     preserve_prefixes: Option<Vec<String>>,
     #[serde(default = "bool::default")]
     force: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            remove: default_remove(),
+            minify: default_minify(),
+            preserve: None,
+            preserve_prefixes: None,
+            force: bool::default(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::utils::cleanup_values::{self, CleanupValues, Mode};
 
-#[derive(Deserialize, Serialize, Default, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CleanupListOfValues {
     #[serde(default = "default_float_precision")]
@@ -17,6 +17,17 @@ pub struct CleanupListOfValues {
     default_px: bool,
     #[serde(default = "default_convert_to_px")]
     convert_to_px: bool,
+}
+
+impl Default for CleanupListOfValues {
+    fn default() -> Self {
+        CleanupListOfValues {
+            float_precision: default_float_precision(),
+            leading_zero: default_leading_zero(),
+            default_px: default_default_px(),
+            convert_to_px: default_convert_to_px(),
+        }
+    }
 }
 
 impl<E: Element> Visitor<E> for CleanupListOfValues {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
@@ -10,13 +10,13 @@ use crate::utils::cleanup_values::{self, CleanupValues, Mode};
 #[serde(rename_all = "camelCase")]
 pub struct CleanupListOfValues {
     #[serde(default = "default_float_precision")]
-    float_precision: usize,
+    pub float_precision: usize,
     #[serde(default = "default_leading_zero")]
-    leading_zero: bool,
+    pub leading_zero: bool,
     #[serde(default = "default_default_px")]
-    default_px: bool,
+    pub default_px: bool,
     #[serde(default = "default_convert_to_px")]
-    convert_to_px: bool,
+    pub convert_to_px: bool,
 }
 
 impl Default for CleanupListOfValues {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
@@ -10,13 +10,13 @@ use crate::utils::cleanup_values::{self, CleanupValues, Mode};
 #[serde(rename_all = "camelCase")]
 pub struct CleanupNumericValues {
     #[serde(default = "default_float_precision")]
-    float_precision: usize,
+    pub float_precision: usize,
     #[serde(default = "default_leading_zero")]
-    leading_zero: bool,
+    pub leading_zero: bool,
     #[serde(default = "default_default_px")]
-    default_px: bool,
+    pub default_px: bool,
     #[serde(default = "default_convert_to_px")]
-    convert_to_px: bool,
+    pub convert_to_px: bool,
 }
 
 impl Default for CleanupNumericValues {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::utils::cleanup_values::{self, CleanupValues, Mode};
 
-#[derive(Deserialize, Serialize, Default, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CleanupNumericValues {
     #[serde(default = "default_float_precision")]
@@ -17,6 +17,17 @@ pub struct CleanupNumericValues {
     default_px: bool,
     #[serde(default = "default_convert_to_px")]
     convert_to_px: bool,
+}
+
+impl Default for CleanupNumericValues {
+    fn default() -> Self {
+        CleanupNumericValues {
+            float_precision: default_float_precision(),
+            leading_zero: default_leading_zero(),
+            default_px: default_default_px(),
+            convert_to_px: default_convert_to_px(),
+        }
+    }
 }
 
 impl<E: Element> Visitor<E> for CleanupNumericValues {

--- a/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
+++ b/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct CollapseGroups(bool);
+pub struct CollapseGroups(pub bool);
 
 impl<E: Element> Visitor<E> for CollapseGroups {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/convert_colors.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_colors.rs
@@ -111,7 +111,10 @@ impl<E: Element> Visitor<E> for ConvertColors {
                     if method.convert_presentation(&mut presentation) {
                         Some(
                             presentation
-                                .value_to_css_string(PrinterOptions::default())
+                                .value_to_css_string(PrinterOptions {
+                                    minify: true,
+                                    ..Default::default()
+                                })
                                 .unwrap(),
                         )
                     } else {
@@ -169,7 +172,10 @@ impl Method {
     }
 
     fn to_css(&self, style: &StyleAttribute) -> Result<String, PrinterError> {
-        let printer_options = PrinterOptions::default();
+        let printer_options = PrinterOptions {
+            minify: true,
+            ..Default::default()
+        };
         // NOTE: Useless destructure, maybe we'll use this in the future?
         let (..) = match self {
             Self::Value {
@@ -190,7 +196,7 @@ impl Method {
         };
 
         let mut s = String::with_capacity(1);
-        let mut dest = Printer::new(&mut s, PrinterOptions::default());
+        let mut dest = Printer::new(&mut s, printer_options);
         let len =
             style.declarations.declarations.len() + style.declarations.important_declarations.len();
         let mut i = 0;

--- a/crates/oxvg_optimiser/src/jobs/convert_colors.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_colors.rs
@@ -104,19 +104,18 @@ impl<E: Element> Visitor<E> for ConvertColors {
                 };
 
                 method.convert_style(&mut style);
-                let minified_style = method.to_css(&style).unwrap();
-                attr.set_value(minified_style.into());
+                if let Ok(minified_style) = method.to_css(&style) {
+                    attr.set_value(minified_style.into());
+                }
             } else {
                 let minified_value = if let Some(mut presentation) = attr.presentation() {
                     if method.convert_presentation(&mut presentation) {
-                        Some(
-                            presentation
-                                .value_to_css_string(PrinterOptions {
-                                    minify: true,
-                                    ..Default::default()
-                                })
-                                .unwrap(),
-                        )
+                        presentation
+                            .value_to_css_string(PrinterOptions {
+                                minify: true,
+                                ..Default::default()
+                            })
+                            .ok()
                     } else {
                         None
                     }

--- a/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
@@ -8,7 +8,7 @@ use super::ContextFlags;
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ConvertEllipseToCircle(bool);
+pub struct ConvertEllipseToCircle(pub bool);
 
 impl<E: Element> Visitor<E> for ConvertEllipseToCircle {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
@@ -6,7 +6,7 @@ use oxvg_path::{convert, geometry::MakeArcs, Path};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Deserialize, Serialize, Default, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ConvertPathData {
@@ -41,6 +41,26 @@ pub struct ConvertPathData {
     // apply_transforms: Option<bool>,
     // apply_transforms_stroked: Option<bool>,
     // transform_precision: Option<usize>,
+}
+
+impl Default for ConvertPathData {
+    fn default() -> Self {
+        ConvertPathData {
+            remove_useless: flag_default_true(),
+            smart_arc_rounding: flag_default_true(),
+            straight_curves: flag_default_true(),
+            convert_to_q: flag_default_true(),
+            line_shorthands: flag_default_true(),
+            collapse_repeated: flag_default_true(),
+            curve_smooth_shorthands: flag_default_true(),
+            convert_to_z: flag_default_true(),
+            force_absolute_path: bool::default(),
+            negative_extra_space: flag_default_true(),
+            make_arcs: MakeArcs::default(),
+            float_precision: Precision::default(),
+            utilize_absolute: flag_default_true(),
+        }
+    }
 }
 
 #[derive(Clone, Default, Copy, Debug)]

--- a/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
@@ -11,31 +11,31 @@ use serde_json::Value;
 #[allow(clippy::struct_excessive_bools)]
 pub struct ConvertPathData {
     #[serde(default = "flag_default_true")]
-    remove_useless: bool,
+    pub remove_useless: bool,
     #[serde(default = "flag_default_true")]
-    smart_arc_rounding: bool,
+    pub smart_arc_rounding: bool,
     #[serde(default = "flag_default_true")]
-    straight_curves: bool,
+    pub straight_curves: bool,
     #[serde(default = "flag_default_true")]
-    convert_to_q: bool,
+    pub convert_to_q: bool,
     #[serde(default = "flag_default_true")]
-    line_shorthands: bool,
+    pub line_shorthands: bool,
     #[serde(default = "flag_default_true")]
-    collapse_repeated: bool,
+    pub collapse_repeated: bool,
     #[serde(default = "flag_default_true")]
-    curve_smooth_shorthands: bool,
+    pub curve_smooth_shorthands: bool,
     #[serde(default = "flag_default_true")]
-    convert_to_z: bool,
+    pub convert_to_z: bool,
     #[serde(default = "bool::default")]
-    force_absolute_path: bool,
+    pub force_absolute_path: bool,
     #[serde(default = "flag_default_true")]
-    negative_extra_space: bool,
+    pub negative_extra_space: bool,
     #[serde(default = "MakeArcs::default")]
-    make_arcs: MakeArcs,
+    pub make_arcs: MakeArcs,
     #[serde(default = "Precision::default")]
-    float_precision: Precision,
+    pub float_precision: Precision,
     #[serde(default = "flag_default_true")]
-    utilize_absolute: bool,
+    pub utilize_absolute: bool,
     // TODO: Do we want to have apply_transforms as an option, or is it better to have this as a plugin
     // just *before* this one
     // apply_transforms: Option<bool>,

--- a/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
@@ -13,8 +13,8 @@ use super::convert_path_data::Precision;
 #[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ConvertShapeToPath {
-    convert_arcs: Option<bool>,
-    float_precision: Option<Precision>,
+    pub convert_arcs: Option<bool>,
+    pub float_precision: Option<Precision>,
 }
 
 impl<E: Element> Visitor<E> for ConvertShapeToPath {

--- a/crates/oxvg_optimiser/src/jobs/convert_transform.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_transform.rs
@@ -112,13 +112,18 @@ impl ConvertTransform {
                 log::debug!("transform_attr: updating {name}");
                 let value = match value.inner().id() {
                     Id::Attr(PresentationAttrId::Transform) => {
-                        transform.to_css_string(PrinterOptions::default())
+                        transform.to_css_string(PrinterOptions {
+                            minify: true,
+                            ..Default::default()
+                        })
                     }
                     Id::Attr(
                         PresentationAttrId::GradientTransform
                         | PresentationAttrId::PatternTransform,
-                    ) => Into::<TransformList>::into(transform)
-                        .to_css_string(PrinterOptions::default()),
+                    ) => Into::<TransformList>::into(transform).to_css_string(PrinterOptions {
+                        minify: true,
+                        ..Default::default()
+                    }),
                     _ => return,
                 }
                 .unwrap_or_default();

--- a/crates/oxvg_optimiser/src/jobs/convert_transform.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_transform.rs
@@ -17,15 +17,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ConvertTransform {
-    convert_to_shorts: Option<bool>,
+    pub convert_to_shorts: Option<bool>,
     // NOTE: Some of the precision will be thrown out by lightningcss' serialization
-    deg_precision: Option<i32>,
-    float_precision: Option<i32>,
-    transform_precision: Option<i32>,
-    matrix_to_transform: Option<bool>,
-    short_rotate: Option<bool>,
-    remove_useless: Option<bool>,
-    collapse_into_one: Option<bool>,
+    pub deg_precision: Option<i32>,
+    pub float_precision: Option<i32>,
+    pub transform_precision: Option<i32>,
+    pub matrix_to_transform: Option<bool>,
+    pub short_rotate: Option<bool>,
+    pub remove_useless: Option<bool>,
+    pub collapse_into_one: Option<bool>,
 }
 
 #[allow(clippy::struct_excessive_bools)]

--- a/crates/oxvg_optimiser/src/jobs/inline_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/inline_styles.rs
@@ -98,12 +98,8 @@ impl<E: Element> Visitor<E> for InlineStyles<E> {
             return Ok(());
         }
 
-        if let Some(style_type) = element
-            .get_attribute_local(&"type".into())
-            .as_deref()
-            .map(AsRef::as_ref)
-        {
-            if !style_type.is_empty() && style_type != "text/css" {
+        if let Some(style_type) = element.get_attribute_local(&"type".into()) {
+            if !style_type.is_empty() && style_type.as_ref() != "text/css" {
                 log::debug!("Not merging style: unsupported type");
                 return Ok(());
             }
@@ -352,7 +348,10 @@ impl<E: Element> InlineStyles<E> {
         selected: impl Iterator<Item = &'a E>,
         style_rule: &rules::style::StyleRule,
         declarations: &str,
-    ) -> Option<Vec<RemovedToken<E>>> {
+    ) -> Option<Vec<RemovedToken<E>>>
+    where
+        E: 'a,
+    {
         let matching_classes: Vec<(Vec<E::Atom>, u32)> = style_rule
             .selectors
             .0
@@ -403,7 +402,10 @@ impl<E: Element> InlineStyles<E> {
         selected: impl Iterator<Item = &'a E>,
         style_rule: &rules::style::StyleRule,
         declarations: &str,
-    ) -> Option<Vec<RemovedToken<E>>> {
+    ) -> Option<Vec<RemovedToken<E>>>
+    where
+        E: 'a,
+    {
         let matching_ids: Vec<(E::Atom, u32)> = style_rule
             .selectors
             .0
@@ -442,7 +444,10 @@ impl<E: Element> InlineStyles<E> {
         selected: impl Iterator<Item = &'a E>,
         style_rule: &rules::style::StyleRule,
         declarations: &str,
-    ) -> Option<Vec<RemovedToken<E>>> {
+    ) -> Option<Vec<RemovedToken<E>>>
+    where
+        E: 'a,
+    {
         #[allow(clippy::redundant_closure_for_method_calls)]
         let matching: Vec<u32> = style_rule
             .selectors

--- a/crates/oxvg_optimiser/src/jobs/inline_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/inline_styles.rs
@@ -44,7 +44,7 @@ pub struct ParentTokens {
     ids: BTreeSet<String>,
 }
 
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Options {
     /// If to only inline styles if the selector matches one element.
@@ -69,6 +69,18 @@ pub struct Options {
     /// element.
     /// e.g. `.foo .bar` would record `.foo` as a parent token.
     pub parent_tokens: ParentTokens,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            only_matched_once: default_only_matched_once(),
+            remove_matched_selectors: default_remove_matched_selectors(),
+            use_mqs: default_use_mqs(),
+            use_pseudos: default_use_pseudos(),
+            parent_tokens: ParentTokens::default(),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/crates/oxvg_optimiser/src/jobs/merge_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_paths.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct MergePaths {
     #[serde(default = "default_force")]
-    force: bool,
+    pub force: bool,
 }
 
 impl Default for MergePaths {

--- a/crates/oxvg_optimiser/src/jobs/merge_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_paths.rs
@@ -16,11 +16,19 @@ use oxvg_ast::{
 use oxvg_path::{command, Path};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MergePaths {
     #[serde(default = "default_force")]
     force: bool,
+}
+
+impl Default for MergePaths {
+    fn default() -> Self {
+        MergePaths {
+            force: default_force(),
+        }
+    }
 }
 
 impl<E: Element> Visitor<E> for MergePaths {

--- a/crates/oxvg_optimiser/src/jobs/merge_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_styles.rs
@@ -31,12 +31,8 @@ impl<E: Element> Visitor<E> for MergeStyles<E> {
             return Ok(());
         }
 
-        if let Some(style_type) = element
-            .get_attribute_local(&"type".into())
-            .as_deref()
-            .map(Atom::as_str)
-        {
-            if !style_type.is_empty() && style_type != "text/css" {
+        if let Some(style_type) = element.get_attribute_local(&"type".into()) {
+            if !style_type.is_empty() && style_type.as_ref() != "text/css" {
                 log::debug!("Not merging style: unsupported type");
                 return Ok(());
             }

--- a/crates/oxvg_optimiser/src/jobs/minify_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/minify_styles.rs
@@ -24,7 +24,7 @@ pub enum RemoveUnused {
 #[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MinifyStyles {
-    remove_unused: Option<RemoveUnused>,
+    pub remove_unused: Option<RemoveUnused>,
 }
 
 impl<E: Element> Visitor<E> for MinifyStyles {

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -15,7 +15,7 @@ macro_rules! jobs {
         #[derive(Deserialize, Serialize, Clone)]
         #[serde(rename_all = "camelCase", bound = "E: Element")]
         pub struct Jobs<E: Element> {
-            $($name: Option<$job $( < $($t),* >)?>),+
+            $(pub $name: Option<$job $( < $($t),* >)?>),+
         }
 
         impl<E: Element> Default for Jobs<E> {

--- a/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct MoveElemsAttrsToGroup(bool);
+pub struct MoveElemsAttrsToGroup(pub bool);
 
 impl<E: Element> Visitor<E> for MoveElemsAttrsToGroup {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct MoveGroupAttrsToElems(bool);
+pub struct MoveGroupAttrsToElems(pub bool);
 
 impl<E: Element> Visitor<E> for MoveGroupAttrsToElems {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use derive_where::derive_where;
 use itertools::Itertools;
 use lightningcss::{
     printer::PrinterOptions,

--- a/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
@@ -45,7 +45,6 @@ const fn default_prefix_class_names() -> bool {
 }
 
 #[derive(Deserialize, Serialize, Clone)]
-#[derive_where(Default)]
 #[serde(rename_all = "camelCase")]
 #[serde(bound = "E: Element")]
 pub struct PrefixIds<E: Element> {
@@ -57,6 +56,17 @@ pub struct PrefixIds<E: Element> {
     pub prefix_ids: bool,
     #[serde(default = "default_prefix_class_names")]
     pub prefix_class_names: bool,
+}
+
+impl<E: Element> Default for PrefixIds<E> {
+    fn default() -> Self {
+        PrefixIds {
+            delim: default_delim(),
+            prefix: PrefixGenerator::default(),
+            prefix_ids: default_prefix_ids(),
+            prefix_class_names: default_prefix_class_names(),
+        }
+    }
 }
 
 struct CssVisitor<'a, 'b, E: Element> {

--- a/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
@@ -14,7 +14,7 @@ pub struct Selector {
 
 #[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveAttributesBySelector(Vec<Selector>);
+pub struct RemoveAttributesBySelector(pub Vec<Selector>);
 
 impl<E: Element> Visitor<E> for RemoveAttributesBySelector {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
@@ -17,13 +17,13 @@ const fn default_preserve_current_color() -> bool {
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveAttrs {
-    attrs: Vec<String>,
+    pub attrs: Vec<String>,
     #[serde(default = "default_elem_separator")]
-    elem_separator: String,
+    pub elem_separator: String,
     #[serde(default = "default_preserve_current_color")]
-    preserve_current_color: bool,
+    pub preserve_current_color: bool,
     #[serde(skip_deserializing, skip_serializing)]
-    parsed_attrs: Vec<[regex::Regex; 3]>,
+    pub parsed_attrs: Vec<[regex::Regex; 3]>,
 }
 
 impl Default for RemoveAttrs {

--- a/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
@@ -14,7 +14,7 @@ const fn default_preserve_current_color() -> bool {
     false
 }
 
-#[derive(Deserialize, Serialize, Default, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveAttrs {
     attrs: Vec<String>,
@@ -24,6 +24,17 @@ pub struct RemoveAttrs {
     preserve_current_color: bool,
     #[serde(skip_deserializing, skip_serializing)]
     parsed_attrs: Vec<[regex::Regex; 3]>,
+}
+
+impl Default for RemoveAttrs {
+    fn default() -> Self {
+        RemoveAttrs {
+            attrs: Default::default(),
+            elem_separator: default_elem_separator(),
+            preserve_current_color: default_preserve_current_color(),
+            parsed_attrs: Default::default(),
+        }
+    }
 }
 
 fn create_regex(part: &str) -> Result<regex::Regex, regex::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_comments.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_comments.rs
@@ -9,7 +9,7 @@ pub struct RemoveComments {
 }
 
 #[derive(Debug, Clone)]
-pub struct PreservePattern(regex::Regex);
+pub struct PreservePattern(pub regex::Regex);
 
 impl<E: Element> Visitor<E> for RemoveComments {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
@@ -72,11 +72,19 @@ impl<'a> AttrStylesheet<'a> {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveDeprecatedAttrs {
     #[serde(default = "default_remove_unsafe")]
     remove_unsafe: bool,
+}
+
+impl Default for RemoveDeprecatedAttrs {
+    fn default() -> Self {
+        RemoveDeprecatedAttrs {
+            remove_unsafe: default_remove_unsafe(),
+        }
+    }
 }
 
 impl<E: Element> Visitor<E> for RemoveDeprecatedAttrs {

--- a/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
@@ -76,7 +76,7 @@ impl<'a> AttrStylesheet<'a> {
 #[serde(rename_all = "camelCase")]
 pub struct RemoveDeprecatedAttrs {
     #[serde(default = "default_remove_unsafe")]
-    remove_unsafe: bool,
+    pub remove_unsafe: bool,
 }
 
 impl Default for RemoveDeprecatedAttrs {

--- a/crates/oxvg_optimiser/src/jobs/remove_desc.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_desc.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct RemoveDesc {
-    remove_any: Option<bool>,
+    pub remove_any: Option<bool>,
 }
 
 impl<E: Element> Visitor<E> for RemoveDesc {

--- a/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveDimensions(bool);
+pub struct RemoveDimensions(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveDimensions {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveDoctype(bool);
+pub struct RemoveDoctype(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveDoctype {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
@@ -6,12 +6,21 @@ use oxvg_ast::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct RemoveElementsByAttr {
     #[serde(default = "Vec::new")]
     id: Vec<String>,
     #[serde(default = "Vec::new")]
     class: Vec<String>,
+}
+
+impl Default for RemoveElementsByAttr {
+    fn default() -> Self {
+        RemoveElementsByAttr {
+            id: Vec::new(),
+            class: Vec::new(),
+        }
+    }
 }
 
 impl<E: Element> Visitor<E> for RemoveElementsByAttr {

--- a/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Clone)]
 pub struct RemoveElementsByAttr {
     #[serde(default = "Vec::new")]
-    id: Vec<String>,
+    pub id: Vec<String>,
     #[serde(default = "Vec::new")]
-    class: Vec<String>,
+    pub class: Vec<String>,
 }
 
 impl Default for RemoveElementsByAttr {

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveEmptyAttrs(bool);
+pub struct RemoveEmptyAttrs(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveEmptyAttrs {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveEmptyContainers(bool);
+pub struct RemoveEmptyContainers(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveEmptyContainers {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveEmptyText {
-    text: Option<bool>,
-    tspan: Option<bool>,
-    tref: Option<bool>,
+    pub text: Option<bool>,
+    pub tspan: Option<bool>,
+    pub tref: Option<bool>,
 }
 
 impl<E: Element> Visitor<E> for RemoveEmptyText {

--- a/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
@@ -24,21 +24,21 @@ use crate::utils::find_references;
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct Options {
-    is_hidden: Option<bool>,
-    display_none: Option<bool>,
-    opacity_zero: Option<bool>,
-    circle_r_zero: Option<bool>,
-    ellipse_rx_zero: Option<bool>,
-    ellipse_ry_zero: Option<bool>,
-    rect_width_zero: Option<bool>,
-    rect_height_zero: Option<bool>,
-    pattern_width_zero: Option<bool>,
-    pattern_height_zero: Option<bool>,
-    image_width_zero: Option<bool>,
-    image_height_zero: Option<bool>,
-    path_empty_d: Option<bool>,
-    polyline_empty_points: Option<bool>,
-    polygon_empty_points: Option<bool>,
+    pub is_hidden: Option<bool>,
+    pub display_none: Option<bool>,
+    pub opacity_zero: Option<bool>,
+    pub circle_r_zero: Option<bool>,
+    pub ellipse_rx_zero: Option<bool>,
+    pub ellipse_ry_zero: Option<bool>,
+    pub rect_width_zero: Option<bool>,
+    pub rect_height_zero: Option<bool>,
+    pub pattern_width_zero: Option<bool>,
+    pub pattern_height_zero: Option<bool>,
+    pub image_width_zero: Option<bool>,
+    pub image_height_zero: Option<bool>,
+    pub path_empty_d: Option<bool>,
+    pub polyline_empty_points: Option<bool>,
+    pub polygon_empty_points: Option<bool>,
 }
 
 #[derive(Clone)]

--- a/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveMetadata(bool);
+pub struct RemoveMetadata(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveMetadata {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveNonInheritableGroupAttrs(bool);
+pub struct RemoveNonInheritableGroupAttrs(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveNonInheritableGroupAttrs {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
@@ -7,18 +7,18 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default)]
 pub struct RemoveOffCanvasPaths {
-    enabled: bool,
-    view_box_data: Option<ViewBoxData>,
+    pub enabled: bool,
+    pub view_box_data: Option<ViewBoxData>,
 }
 
 #[derive(Default, Clone)]
-struct ViewBoxData {
-    top: f64,
-    right: f64,
-    bottom: f64,
-    left: f64,
-    width: f64,
-    height: f64,
+pub struct ViewBoxData {
+    pub top: f64,
+    pub right: f64,
+    pub bottom: f64,
+    pub left: f64,
+    pub width: f64,
+    pub height: f64,
 }
 
 impl<E: Element> Visitor<E> for RemoveOffCanvasPaths {

--- a/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveRasterImages(bool);
+pub struct RemoveRasterImages(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveRasterImages {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
@@ -9,7 +9,7 @@ use oxvg_collections::collections::EVENT_ATTRS;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Default)]
-pub struct RemoveScripts(bool);
+pub struct RemoveScripts(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveScripts {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
@@ -5,7 +5,7 @@ use oxvg_ast::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Default)]
-pub struct RemoveStyleElement(bool);
+pub struct RemoveStyleElement(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveStyleElement {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_title.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_title.rs
@@ -5,7 +5,7 @@ use oxvg_ast::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
-pub struct RemoveTitle(bool);
+pub struct RemoveTitle(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveTitle {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
@@ -20,21 +20,21 @@ use serde::{Deserialize, Serialize};
 #[allow(clippy::struct_excessive_bools)]
 pub struct RemoveUnknownsAndDefaults {
     #[serde(default = "default_unknown_content")]
-    unknown_content: bool,
+    pub unknown_content: bool,
     #[serde(default = "default_unknown_attrs")]
-    unknown_attrs: bool,
+    pub unknown_attrs: bool,
     #[serde(default = "default_default_attrs")]
-    default_attrs: bool,
+    pub default_attrs: bool,
     #[serde(default = "default_default_markup_declarations")]
-    default_markup_declarations: bool,
+    pub default_markup_declarations: bool,
     #[serde(default = "default_useless_overrides")]
-    useless_overrides: bool,
+    pub useless_overrides: bool,
     #[serde(default = "default_keep_data_attrs")]
-    keep_data_attrs: bool,
+    pub keep_data_attrs: bool,
     #[serde(default = "default_keep_aria_attrs")]
-    keep_aria_attrs: bool,
+    pub keep_aria_attrs: bool,
     #[serde(default = "default_keep_role_attr")]
-    keep_role_attr: bool,
+    pub keep_role_attr: bool,
 }
 
 impl Default for RemoveUnknownsAndDefaults {

--- a/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
@@ -15,7 +15,7 @@ use oxvg_collections::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::struct_excessive_bools)]
 pub struct RemoveUnknownsAndDefaults {
@@ -35,6 +35,21 @@ pub struct RemoveUnknownsAndDefaults {
     keep_aria_attrs: bool,
     #[serde(default = "default_keep_role_attr")]
     keep_role_attr: bool,
+}
+
+impl Default for RemoveUnknownsAndDefaults {
+    fn default() -> Self {
+        RemoveUnknownsAndDefaults {
+            unknown_content: default_unknown_content(),
+            unknown_attrs: default_unknown_attrs(),
+            default_attrs: default_default_attrs(),
+            default_markup_declarations: default_default_markup_declarations(),
+            useless_overrides: default_useless_overrides(),
+            keep_data_attrs: default_keep_data_attrs(),
+            keep_aria_attrs: default_keep_aria_attrs(),
+            keep_role_attr: default_keep_role_attr(),
+        }
+    }
 }
 
 impl<E: Element> Visitor<E> for RemoveUnknownsAndDefaults {

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveUselessDefs(bool);
+pub struct RemoveUselessDefs(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveUselessDefs {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -18,13 +18,13 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct RemoveUselessStrokeAndFill {
     #[serde(default = "default_stroke")]
-    stroke: bool,
+    pub stroke: bool,
     #[serde(default = "default_fill")]
-    fill: bool,
+    pub fill: bool,
     #[serde(default = "default_remove_none")]
-    remove_none: bool,
+    pub remove_none: bool,
     #[serde(skip_deserializing, skip_serializing)]
-    id_rc_byte: Option<usize>,
+    pub id_rc_byte: Option<usize>,
 }
 
 impl Default for RemoveUselessStrokeAndFill {

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -14,7 +14,7 @@ use oxvg_ast::{
 use oxvg_collections::collections::{ElementGroup, Group};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveUselessStrokeAndFill {
     #[serde(default = "default_stroke")]
@@ -25,6 +25,17 @@ pub struct RemoveUselessStrokeAndFill {
     remove_none: bool,
     #[serde(skip_deserializing, skip_serializing)]
     id_rc_byte: Option<usize>,
+}
+
+impl Default for RemoveUselessStrokeAndFill {
+    fn default() -> Self {
+        RemoveUselessStrokeAndFill {
+            stroke: default_stroke(),
+            fill: default_fill(),
+            remove_none: default_remove_none(),
+            id_rc_byte: None,
+        }
+    }
 }
 
 impl<E: Element> Visitor<E> for RemoveUselessStrokeAndFill {

--- a/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveViewBox(bool);
+pub struct RemoveViewBox(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveViewBox {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/remove_xml_proc_inst.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_xml_proc_inst.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RemoveXMLProcInst(bool);
+pub struct RemoveXMLProcInst(pub bool);
 
 impl<E: Element> Visitor<E> for RemoveXMLProcInst {
     type Error = String;

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_colors__convert_colors-5.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_colors__convert_colors-5.snap
@@ -5,7 +5,7 @@ expression: "test_config(r#\"{ \"convertColors\": { } }\"#,\nSome(r#\"<svg xmlns
 <svg xmlns="http://www.w3.org/2000/svg">
     <!-- Should preserve color-like substrings that aren't colors -->
     <linearGradient id="Aa">
-        <stop stop-color="ReD" offset="5%"/>
+        <stop stop-color="red" offset="5%"/>
     </linearGradient>
     <text x="0" y="32" fill="gold">
         uwu
@@ -13,7 +13,7 @@ expression: "test_config(r#\"{ \"convertColors\": { } }\"#,\nSome(r#\"<svg xmlns
     <text x="0" y="64" fill="gold">
         owo
     </text>
-    <text x="0" y="96" fill="url(&quot;#Aa&quot;)">
+    <text x="0" y="96" fill="url(#Aa)">
         eue
     </text>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "lowercase")]
-enum XMLNSOrder {
+pub enum XMLNSOrder {
     Alphabetical,
     #[default]
     Front,
@@ -16,8 +16,8 @@ enum XMLNSOrder {
 #[derive(Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SortAttrs {
-    order: Option<Vec<String>>,
-    xmlns_order: Option<XMLNSOrder>,
+    pub order: Option<Vec<String>>,
+    pub xmlns_order: Option<XMLNSOrder>,
 }
 
 impl<E: Element> Visitor<E> for SortAttrs {

--- a/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
@@ -8,7 +8,7 @@ use oxvg_ast::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone)]
-pub struct SortDefsChildren(bool);
+pub struct SortDefsChildren(pub bool);
 
 impl<E: Element> Visitor<E> for SortDefsChildren {
     type Error = String;


### PR DESCRIPTION
First of all, thanks for building this project! Very excited about it. I'm working on a Rust-based HTML transformer/minifier for [Parcel](https://github.com/parcel-bundler/parcel), and was able to take advantage of oxvg for embedded SVGs in HTML. This PR includes several things I needed in order to get that working. See https://github.com/parcel-bundler/parcel/pull/10090.

### Trait lifetimes

For my HTML transformer, I'm using html5ever with a custom DOM implementation that uses an arena allocator rather than rcdom. This improves allocation performance, and also makes some things easier by passing around references rather than clones. However, oxvg's `Node` trait currently requires `'static` lifetimes, and does some dynamic dispatch stuff that mean it's not possible to implement when a node has references. I was able to avoid this by defining a `Parent` associated type rather than using `impl`.

I also needed to return `Atom` directly from methods like `get_attribute`. I couldn't figure out a way to return a reference with lifetimes and an `impl Deref`. Maybe there's a way but cloning these seems ok since it is just a reference count. Do you have benchmarks showing significant overhead here?

### Config options

Many of the jobs have `#[serde(default)]` attributes defined, but these don't apply when constructing the options programmatically. I've added manual implementations of the `Default` trait matching these serde defaults. An alternative would be a proc macro to automatically generate these, but it didn't seem too hard to just do it manually.

I've also marked all of the config properties as `pub` so they can be set programmatically.

### Other fixes

While testing, I noticed that the `convert_colors` job was converting more attributes than just colors. For example, `<rect width="100">` was becoming `<rect width="100px">`. This is because it was parsing all attributes as CSS, and then re-serializing them. I've addressed this by parsing only presentation attributes, and only converting color properties.