### PR TITLE
Fix some correctness tests

### DIFF
--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -72,8 +72,8 @@ impl<'i> UnparsedPresentationAttr<'i> {
     ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
         let value = CustomProperty::parse(CustomPropertyName::Unknown("".into()), input, options)?;
         input.expect_exhausted()?; // !important is not supported in presentation attributes
-        // TODO: Port to lightningcss as
-        // let value = input.parse_entirely(|input| TokenList::parse(input, options, 0))?;
+                                   // TODO: Port to lightningcss as
+                                   // let value = input.parse_entirely(|input| TokenList::parse(input, options, 0))?;
         Ok(UnparsedPresentationAttr {
             presentation_attr_id,
             value: value.value,
@@ -1674,6 +1674,7 @@ impl<'i> ComputedStyles<'i> {
             return self;
         };
         let parent_styles = ComputedStyles::default().with_all(&parent, styles, element_styles);
+        self.inherited.extend(parent_styles.inherited);
         self.inherited.extend(
             parent_styles
                 .attr

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -386,8 +386,8 @@ define_presentation_attrs! {
     // NOTE: I think these may technically may not be presentation attrs, but they contain css so
     // may be worth considering
     // TODO: If so, maybe `is_presentation` method would be needed
-    "gradientTransform": GradientTransform(TransformList) / false,
-    "patternTransform": PatternTransform(TransformList) / false,
+    "gradientTransform": GradientTransform(SVGTransformList) / false,
+    "patternTransform": PatternTransform(SVGTransformList) / false,
 
     // NOTE: We could include `d`, as is done with https://github.com/parcel-bundler/lightningcss/pull/868
     // "d": Definition(PathData) / false,
@@ -1192,51 +1192,38 @@ impl<'i> Parse<'i> for SVGTransform {
     fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
         input
             .try_parse(|input| {
-                let function = input.expect_function()?.clone();
+                // SVG transforms allow whitespace between the function name and arguments, unlike CSS functions.
+                // So this may tokenize either as a function, or as an ident followed by a parenthesis block.
+                let function = input
+                    .try_parse(|input| input.expect_function().map(|f| f.clone()))
+                    .or_else(|_| -> Result<_, ParseError<_>> {
+                        let name = input.expect_ident_cloned()?;
+                        input.skip_whitespace();
+                        input.expect_parenthesis_block()?;
+                        Ok(name)
+                    })?;
+
                 let function_case_sensitive: &str = &function;
                 input.parse_nested_block(|input| {
                     let location = input.current_source_location();
                     match function_case_sensitive {
                         "matrix" => {
                             let a = f32::parse(input)?;
-                            input
-                                .try_parse(Parser::expect_comma)
-                                .or_else(|_| input.try_parse(Parser::expect_comma))
-                                .ok();
+                            skip_comma_and_whitespace(input);
                             let b = f32::parse(input)?;
-                            input
-                                .try_parse(Parser::expect_comma)
-                                .or_else(|_| input.try_parse(Parser::expect_comma))
-                                .ok();
+                            skip_comma_and_whitespace(input);
                             let c = f32::parse(input)?;
-                            input
-                                .try_parse(Parser::expect_comma)
-                                .or_else(|_| input.try_parse(Parser::expect_comma))
-                                .ok();
+                            skip_comma_and_whitespace(input);
                             let d = f32::parse(input)?;
-                            input
-                                .try_parse(Parser::expect_comma)
-                                .or_else(|_| input.try_parse(Parser::expect_comma))
-                                .ok();
+                            skip_comma_and_whitespace(input);
                             let e = f32::parse(input)?;
-                            input
-                                .try_parse(Parser::expect_comma)
-                                .or_else(|_| input.try_parse(Parser::expect_comma))
-                                .ok();
+                            skip_comma_and_whitespace(input);
                             let f = f32::parse(input)?;
                             Ok(SVGTransform::Matrix(Matrix { a, b, c, d, e, f }))
                         }
                         "translate" => {
                             let x = f32::parse(input)?;
-                            input
-                                .try_parse(Parser::expect_comma)
-                                .or_else(|_| input.try_parse(Parser::expect_comma))
-                                .ok();
-                            input.skip_whitespace();
-                            input
-                                .try_parse(Parser::expect_comma)
-                                .or_else(|_| input.try_parse(Parser::expect_comma))
-                                .ok();
+                            skip_comma_and_whitespace(input);
                             if let Ok(y) = input.try_parse(f32::parse) {
                                 Ok(SVGTransform::Translate(x, y))
                             } else {
@@ -1245,7 +1232,7 @@ impl<'i> Parse<'i> for SVGTransform {
                         }
                         "scale" => {
                             let x = f32::parse(input)?;
-                            input.skip_whitespace();
+                            skip_comma_and_whitespace(input);
                             if let Ok(y) = input.try_parse(f32::parse) {
                                 Ok(SVGTransform::Scale(x, y))
                             } else {
@@ -1254,9 +1241,9 @@ impl<'i> Parse<'i> for SVGTransform {
                         }
                         "rotate" => {
                             let angle = f32::parse(input)?;
-                            input.skip_whitespace();
+                            skip_comma_and_whitespace(input);
                             if let Ok(x) = input.try_parse(f32::parse) {
-                                input.skip_whitespace();
+                                skip_comma_and_whitespace(input);
                                 let y = f32::parse(input)?;
                                 Ok(SVGTransform::Rotate(angle, x, y))
                             } else {
@@ -1279,6 +1266,12 @@ impl<'i> Parse<'i> for SVGTransform {
             })
             .or_else(|_| Ok(SVGTransform::CssTransform(Transform::parse(input)?)))
     }
+}
+
+fn skip_comma_and_whitespace<'i, 't>(input: &mut Parser<'i, 't>) {
+    input.skip_whitespace();
+    let _ = input.try_parse(Parser::expect_comma);
+    input.skip_whitespace();
 }
 
 impl ToCss for SVGTransform {

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -71,6 +71,7 @@ impl<'i> UnparsedPresentationAttr<'i> {
         options: &ParserOptions<'_, 'i>,
     ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
         let value = CustomProperty::parse(CustomPropertyName::Unknown("".into()), input, options)?;
+        input.expect_exhausted()?; // !important is not supported in presentation attributes
         // TODO: Port to lightningcss as
         // let value = input.parse_entirely(|input| TokenList::parse(input, options, 0))?;
         Ok(UnparsedPresentationAttr {

--- a/crates/oxvg_ast/src/visitor.rs
+++ b/crates/oxvg_ast/src/visitor.rs
@@ -339,7 +339,9 @@ pub trait Visitor<'arena, E: Element<'arena>> {
                                 &context.stylesheet,
                                 context.element_styles,
                             );
+                            context.flags.set(ContextFlags::use_style, true);
                         } else {
+                            context.computed_styles = ComputedStyles::default();
                             context.flags.set(ContextFlags::use_style, false);
                         }
                         self.element(element, context)?;

--- a/crates/oxvg_ast/src/visitor.rs
+++ b/crates/oxvg_ast/src/visitor.rs
@@ -339,7 +339,6 @@ pub trait Visitor<'arena, E: Element<'arena>> {
                                 &context.stylesheet,
                                 context.element_styles,
                             );
-                            context.flags.set(ContextFlags::use_style, true);
                         } else {
                             context.computed_styles = ComputedStyles::default();
                             context.flags.set(ContextFlags::use_style, false);

--- a/crates/oxvg_collections/src/allowed_content.rs
+++ b/crates/oxvg_collections/src/allowed_content.rs
@@ -3,8 +3,8 @@ use phf::{phf_map, phf_set};
 use crate::collections::{
     ANIMATION, ANIMATION_ADDITION, ANIMATION_ATTRIBUTE_TARGET, ANIMATION_EVENT, ANIMATION_TIMING,
     ANIMATION_VALUE, CONDITIONAL_PROCESSING, CORE, DESCRIPTIVE, DOCUMENT_EVENT, FILTER_PRIMITIVE,
-    GRAPHICAL_EVENT, LIGHT_SOURCE, PAINT_SERVER, PRESENTATION, SHAPE, STRUCTURAL,
-    TEXT_CONTENT_CHILD, TRANSFER_FUNCTION, X_LINK,
+    FILTER_PRIMITIVE_ATTRS, GRAPHICAL_EVENT, LIGHT_SOURCE, PAINT_SERVER, PRESENTATION, SHAPE,
+    STRUCTURAL, TEXT_CONTENT_CHILD, TRANSFER_FUNCTION, X_LINK,
 };
 
 pub struct AllowedContent {
@@ -344,7 +344,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!("class", "style", "in", "in2", "mode")),
         defaults: Some(phf_map!{"mode" => "normal"}),
@@ -357,7 +357,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!("class", "style", "in", "type", "values")),
         defaults: Some(phf_map!{"type" => "matrix"}),
@@ -370,7 +370,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!("class", "style", "in")),
         defaults: None,
@@ -383,7 +383,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!(
             "class", "in", "in2", "k1", "k2", "k3", "k4", "operator", "style",
@@ -404,7 +404,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!(
             "class",
@@ -435,7 +435,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!(
             "class",
@@ -462,7 +462,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!(
             "class",
@@ -496,7 +496,7 @@ pub static ELEMS: phf::Map<&'static str, AllowedContent> = phf_map! {
         attrs_groups: &[
             &CORE,
             &PRESENTATION,
-            &FILTER_PRIMITIVE
+            &FILTER_PRIMITIVE_ATTRS
         ],
         attrs: Some(phf_set!("class", "style")),
         defaults: None,

--- a/crates/oxvg_optimiser/src/jobs/convert_transform.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_transform.rs
@@ -138,16 +138,11 @@ impl ConvertTransform {
 
     fn transform(&self, value: &Style) -> Option<SVGTransformList> {
         let transform = match value {
-            Style::Static(Static::Attr(PresentationAttr::Transform(transform))) => {
-                transform.clone()
-            }
             Style::Static(Static::Attr(
-                PresentationAttr::GradientTransform(transform)
+                PresentationAttr::Transform(transform)
+                | PresentationAttr::GradientTransform(transform)
                 | PresentationAttr::PatternTransform(transform),
-            )) => match transform.try_into() {
-                Ok(transform) => transform,
-                Err(()) => return None,
-            },
+            )) => transform.clone(),
             Style::Static(Static::Attr(PresentationAttr::Unparsed(_))) => return None,
             _ => unreachable!("dynamic or non-transform style provided"),
         };

--- a/crates/oxvg_optimiser/src/jobs/convert_transform.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_transform.rs
@@ -489,5 +489,17 @@ fn convert_transform() -> anyhow::Result<()> {
         ),
     )?);
 
+    insta::assert_snapshot!(test_config(
+        r#"{ "convertTransform": {} }"#,
+        Some(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 480 360">
+    <!-- ignore inherited styles on children -->
+    <g transform="translate(30,-10)">
+      <rect x="0" y="0" width="10" height="20"/>
+    </g>
+</svg>"#
+        ),
+    )?);
+
     Ok(())
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
@@ -561,5 +561,19 @@ fn remove_unknowns_and_defaults() -> anyhow::Result<()> {
         ),
     )?);
 
+    insta::assert_snapshot!(test_config(
+        r#"{ "removeUnknownsAndDefaults": {} }"#,
+        Some(
+            r##"<svg width="50" height="50" xmlns="http://www.w3.org/2000/svg">
+    <!-- do not remove default when inherited value differs -->
+    <g fill="#fff">
+      <g>
+        <rect x="0" y="0" width="50" height="50" fill="#000" />
+      </g>
+    </g>
+</svg>"##
+        ),
+    )?);
+
     Ok(())
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
@@ -67,11 +67,10 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'arena, E> {
         if self.unused_namespaces.is_empty() {
             return Ok(());
         }
-        let Some(prefix) = element.prefix() else {
-            return Ok(());
-        };
+        if let Some(prefix) = element.prefix() {
+            self.unused_namespaces.remove(&prefix.as_ref().into());
+        }
 
-        self.unused_namespaces.remove(&prefix.as_ref().into());
         for attr in element.attributes().into_iter() {
             if let Some(prefix) = attr.prefix() {
                 self.unused_namespaces.remove(&prefix.as_ref().into());

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_transform__convert_transform-14.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_transform__convert_transform-14.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxvg_optimiser/src/jobs/convert_transform.rs
+expression: "test_config(r#\"{ \"convertTransform\": {} }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"500\" height=\"500\" viewBox=\"0 0 480 360\">\n    <!-- ignore inherited styles on children -->\n    <g transform=\"translate(30,-10)\">\n      <rect x=\"0\" y=\"0\" width=\"10\" height=\"20\"/>\n    </g>\n</svg>\"#),)?"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 480 360">
+    <!-- ignore inherited styles on children -->
+    <g transform="translate(30 -10)">
+        <rect x="0" y="0" width="10" height="20"/>
+    </g>
+</svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_transform__convert_transform-4.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_transform__convert_transform-4.snap
@@ -14,5 +14,5 @@ expression: "test_config(r#\"{ \"convertTransform\": {} }\"#,\nSome(r#\"<svg xml
     <g/>
     <g/>
     <g/>
-    <g/>
+    <g transform="rotate(45 34 34)"/>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unknowns_and_defaults__remove_unknowns_and_defaults-17.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unknowns_and_defaults__remove_unknowns_and_defaults-17.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
+expression: "test_config(r#\"{ \"removeUnknownsAndDefaults\": {} }\"#,\nSome(r##\"<svg width=\"50\" height=\"50\" xmlns=\"http://www.w3.org/2000/svg\">\n    <!-- do not remove default when inherited value differs -->\n    <g fill=\"#fff\">\n      <g>\n        <rect x=\"0\" y=\"0\" width=\"50\" height=\"50\" fill=\"#000\" />\n      </g>\n    </g>\n</svg>\"##),)?"
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+    <!-- do not remove default when inherited value differs -->
+    <g fill="#fff">
+        <g>
+            <rect width="50" height="50" fill="#000"/>
+        </g>
+    </g>
+</svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-2.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-2.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
-expression: "test_config(r#\"{ \"removeUnusedNS\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:test=\"http://trololololololololololo.com/\">\n    <g test:attr=\"val\">\n        test\n    </g>\n</svg>\"#),)?"
+expression: "test_config(r#\"{ \"removeUnusedNS\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:test=\"http://test.com/\">\n    <g test:attr=\"val\">\n        test\n    </g>\n</svg>\"#),)?"
 ---
-<svg xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:test="http://test.com/">
     <g test:attr="val">
         test
     </g>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-3.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
-expression: "test_config(r#\"{ \"removeUnusedNS\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:test=\"http://trololololololololololo.com/\" xmlns:test2=\"http://trololololololololololo.com/\">\n    <g test:attr=\"val\">\n        <g>\n            test\n        </g>\n    </g>\n</svg>\"#),)?"
+expression: "test_config(r#\"{ \"removeUnusedNS\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:test=\"http://test.com/\" xmlns:test2=\"http://test2.com/\">\n    <g test:attr=\"val\">\n        <g>\n            test\n        </g>\n    </g>\n</svg>\"#),)?"
 ---
-<svg xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:test="http://test.com/">
     <g test:attr="val">
         <g>
             test

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-4.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-4.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
-expression: "test_config(r#\"{ \"removeUnusedNS\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:test=\"http://trololololololololololo.com/\" xmlns:test2=\"http://trololololololololololo.com/\">\n    <g test:attr=\"val\">\n        <g test2:attr=\"val\">\n            test\n        </g>\n    </g>\n</svg>\"#),)?"
+expression: "test_config(r#\"{ \"removeUnusedNS\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:test=\"http://test.com/\" xmlns:test2=\"http://test2.com/\">\n    <g test:attr=\"val\">\n        <g test2:attr=\"val\">\n            test\n        </g>\n    </g>\n</svg>\"#),)?"
 ---
-<svg xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:test="http://test.com/" xmlns:test2="http://test2.com/">
     <g test:attr="val">
         <g test2:attr="val">
             test

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-7.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unused_n_s__remove_unused_n_s-7.snap
@@ -2,6 +2,6 @@
 source: crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
 expression: "test_config(r#\"{ \"removeUnusedNS\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" inkscape:version=\"0.92.2 (5c3e80d, 2017-08-06)\" sodipodi:docname=\"test.svg\" xmlns:inkscape=\"http://www.inkscape.org/namespaces/inkscape\" xmlns:sodipodi=\"http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd\">\n    test\n</svg>\"#),)?"
 ---
-<svg xmlns="http://www.w3.org/2000/svg" inkscape:version="0.92.2 (5c3e80d, 2017-08-06)" sodipodi:docname="test.svg">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" inkscape:version="0.92.2 (5c3e80d, 2017-08-06)" sodipodi:docname="test.svg">
     test
 </svg>


### PR DESCRIPTION
This reduces the w3c failures to 13. See individual commits. Most of them were fixed by the "fix computed styles" commit, which fixes how styles are inherited and resets computed styles on elements where `use_style` returns false. 

Also fixed how the transform presentation attributes are parsed, which is different from CSS https://drafts.csswg.org/css-transforms/#svg-transform. In particular SVG allows spaces and commas in more places.

I wasn't sure about the remove unused ns tests which seemed incorrect to me, removing namespaces that are actually used. I updated the snapshots accordingly but wasn't sure if this was intentional.

The majority of the remaining test failures are in the `MergePaths` job. When this job is disabled, only 4 items are broken. Some of these also look identical to me in Chrome, so idk if maybe the comparison script is somehow rendering differently.