### PR TITLE
fix: #125 fork xmlwriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,6 @@ dependencies = [
  "tendril",
  "typed-arena",
  "xml5ever",
- "xmlwriter",
 ]
 
 [[package]]
@@ -2663,12 +2662,6 @@ dependencies = [
  "mac",
  "markup5ever",
 ]
-
-[[package]]
-name = "xmlwriter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ tendril = "0.4"
 typed-arena = "2.0"
 quick-xml = "0.31"
 xml5ever = "0.20"
-xmlwriter = "0.1"
 
 # Developer dependencies
 ctor = "0.2"

--- a/crates/oxvg/src/optimise.rs
+++ b/crates/oxvg/src/optimise.rs
@@ -67,7 +67,7 @@ impl RunCommand for Optimise {
 }
 
 impl Optimise {
-    fn handle_out<W: Write>(dom: Ref<'_>, wr: W) -> anyhow::Result<usize> {
+    fn handle_out<W: Write>(dom: Ref<'_>, wr: W) -> anyhow::Result<W> {
         Ok(dom.serialize_into(
             wr,
             Options {

--- a/crates/oxvg_ast/Cargo.toml
+++ b/crates/oxvg_ast/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 default = ["markup5ever", "roxmltree", "visitor"]
 markup5ever = ["dep:rcdom", "dep:xml5ever"]
 roxmltree = ["dep:roxmltree"]
-serialize = ["dep:xmlwriter"]
+serialize = []
 selectors = ["dep:selectors", "dep:cssparser", "dep:precomputed-hash"]
 visitor = ["dep:bitflags"]
 style = ["dep:lightningcss", "dep:cssparser_lightningcss", "dep:smallvec"]
@@ -42,4 +42,3 @@ string_cache = { workspace = true }
 tendril = { workspace = true }
 typed-arena = { workspace = true }
 xml5ever = { workspace = true, optional = true }
-xmlwriter = { workspace = true, optional = true }

--- a/crates/oxvg_ast/src/document.rs
+++ b/crates/oxvg_ast/src/document.rs
@@ -46,7 +46,7 @@ pub trait Document<'arena> {
     /// [MDN | createElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement)
     fn create_element(
         &self,
-        tag_name: <Self::Root as Element<'arena>>::Name,
+        tag_name: <Self::Root as Node<'arena>>::Name,
         arena: &<Self::Root as Node<'arena>>::Arena,
     ) -> Self::Root;
 

--- a/crates/oxvg_ast/src/element.rs
+++ b/crates/oxvg_ast/src/element.rs
@@ -19,8 +19,6 @@ use crate::{
 ///
 /// [MDN | Element](https://developer.mozilla.org/en-US/docs/Web/API/Element)
 pub trait Element<'arena>: Node<'arena> + Debug + std::hash::Hash + Eq + PartialEq {
-    /// The type representing the tag or attribute name of the element
-    type Name: Name;
     /// The type representing a singular attribute of the element's list of attributes
     type Attr: Attr<Name = Self::Name, Atom = <Self as Node<'arena>>::Atom>;
     /// The type representing a list of attributes in an element

--- a/crates/oxvg_ast/src/implementations/roxmltree.rs
+++ b/crates/oxvg_ast/src/implementations/roxmltree.rs
@@ -12,7 +12,6 @@ use std::{
     fmt::Display,
 };
 
-use string_cache::Atom;
 use tendril::StrTendril;
 use xml5ever::{local_name, namespace_prefix, namespace_url, ns, Prefix};
 
@@ -36,7 +35,36 @@ struct Allocator<'arena> {
     current_node_id: usize,
 }
 
-type NamespaceMap = HashMap<Option<Prefix>, Option<StrTendril>>;
+#[derive(Debug, Default)]
+struct NamespaceMap {
+    prefix_to_uri: HashMap<Option<Prefix>, Option<StrTendril>>,
+    uri_to_prefix: HashMap<Option<StrTendril>, Option<Prefix>>,
+}
+
+#[allow(clippy::ref_option)]
+impl NamespaceMap {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(
+        &mut self,
+        prefix: Option<Prefix>,
+        uri: Option<StrTendril>,
+    ) -> Option<(Option<Prefix>, Option<StrTendril>)> {
+        let p = self.uri_to_prefix.insert(uri.clone(), prefix.clone());
+        let u = self.prefix_to_uri.insert(prefix, uri);
+        Some((p?, u?))
+    }
+
+    fn get_by_uri(&self, uri: &Option<StrTendril>) -> Option<&Option<Prefix>> {
+        self.uri_to_prefix.get(uri)
+    }
+
+    fn get_by_prefix(&self, prefix: &Option<Prefix>) -> Option<&Option<StrTendril>> {
+        self.prefix_to_uri.get(prefix)
+    }
+}
 
 impl<'arena> Allocator<'arena> {
     fn alloc(&mut self, node_data: NodeData) -> &'arena mut Node<'arena> {
@@ -97,19 +125,11 @@ pub fn parse_roxmltree<'arena>(
         }
     }
 
-    let mut namespace_map = HashMap::new();
-    let mut prefix_map = HashMap::from([
-        ("xml", "http://www.w3.org/XML/1998/namespace"),
-        ("http://www.w3.org/XML/1998/namespace", "xml"),
-    ]);
-    for ns in xml.descendants().flat_map(|n| n.namespaces()) {
-        if let Some(prefix) = ns.name() {
-            if !prefix_map.contains_key(ns.uri()) {
-                prefix_map.insert(ns.uri(), prefix);
-                prefix_map.insert(prefix, ns.uri());
-            }
-        }
-    }
+    let mut namespace_map = NamespaceMap::new();
+    namespace_map.insert(
+        Some(namespace_prefix!("xml")),
+        Some("http://www.w3.org/XML/1998/namespace".into()),
+    );
 
     let mut allocator = Allocator {
         arena,
@@ -122,7 +142,6 @@ pub fn parse_roxmltree<'arena>(
         &mut allocator,
         xml.root(),
         0,
-        &prefix_map,
         &mut namespace_map,
         None,
     );
@@ -138,27 +157,11 @@ fn parse_xml_node_children<'arena>(
     allocator: &mut Allocator<'arena>,
     parent: roxmltree::Node<'_, '_>,
     depth: u32,
-    prefix_map: &HashMap<&str, &str>,
     namespace_map: &mut NamespaceMap,
     root: Option<&Element<'arena>>,
 ) -> Result<Ref<'arena>, ParseError> {
     for xml_child in parent.children() {
-        let child = parse_xml_node(allocator, xml_child, depth, prefix_map, namespace_map)?;
-        let child_element = (&*child).element();
-        let root = if root.is_some() {
-            root
-        } else {
-            child_element.as_ref()
-        };
-        parse_xml_node_children(
-            child,
-            allocator,
-            xml_child,
-            depth + 1,
-            prefix_map,
-            namespace_map,
-            root,
-        )?;
+        let child = parse_xml_node(allocator, xml_child, depth, namespace_map, root.cloned())?;
 
         // parent
         child.parent.set(Some(node));
@@ -183,40 +186,62 @@ fn parse_xml_node<'arena>(
     allocator: &mut Allocator<'arena>,
     node: roxmltree::Node<'_, '_>,
     depth: u32,
-    prefix_map: &HashMap<&str, &str>,
     namespace_map: &mut NamespaceMap,
-) -> Result<&'arena mut Node<'arena>, ParseError> {
+    root: Option<Element<'arena>>,
+) -> Result<&'arena Node<'arena>, ParseError> {
     if depth > 1024 {
         return Err(ParseError::NodesLimitReached);
     }
 
-    Ok(match node.node_type() {
+    let mut popped_ns: Vec<(Option<Prefix>, Option<StrTendril>)> = vec![];
+    let child = &*match node.node_type() {
         roxmltree::NodeType::Root => create_root(allocator),
         roxmltree::NodeType::PI => parse_pi(allocator, node.pi().unwrap()),
-        roxmltree::NodeType::Element => parse_element(allocator, node, prefix_map, namespace_map),
+        roxmltree::NodeType::Element => {
+            parse_element(allocator, node, namespace_map, &mut popped_ns)
+        }
         roxmltree::NodeType::Comment => parse_comment(allocator, node),
         roxmltree::NodeType::Text => parse_text(allocator, node),
-    })
+    };
+    let root = if root.is_some() {
+        root
+    } else {
+        child.element()
+    };
+    parse_xml_node_children(
+        child,
+        allocator,
+        node,
+        depth + 1,
+        namespace_map,
+        root.as_ref(),
+    )?;
+    for (prefix, value) in popped_ns {
+        namespace_map.insert(prefix, value);
+    }
+    Ok(child)
 }
 
 fn parse_element<'arena>(
     arena: &mut Allocator<'arena>,
     xml_node: roxmltree::Node<'_, '_>,
-    prefix_map: &HashMap<&str, &str>,
     namespace_map: &mut NamespaceMap,
+    popped_ns: &mut Vec<(Option<Prefix>, Option<StrTendril>)>,
 ) -> &'arena mut Node<'arena> {
-    let attrs = xml_node
+    let xmlns: Vec<_> = xml_node
         .namespaces()
-        .filter_map(|ns| find_new_xmlns(ns, namespace_map))
-        .chain(
-            xml_node
-                .attributes()
-                .map(|attr| Attribute::new(parse_attr_name(attr, prefix_map), attr.value().into())),
-        )
+        .filter_map(|ns| find_new_xmlns(ns, namespace_map, popped_ns))
         .collect();
+    let attrs =
+        xmlns
+            .into_iter()
+            .chain(xml_node.attributes().map(|attr| {
+                Attribute::new(parse_attr_name(attr, namespace_map), attr.value().into())
+            }))
+            .collect();
 
     arena.alloc(NodeData::Element {
-        name: parse_expanded_name(xml_node.tag_name(), prefix_map),
+        name: parse_expanded_name(xml_node.tag_name(), namespace_map),
         attrs: RefCell::new(attrs),
         #[cfg(feature = "selectors")]
         selector_flags: Cell::new(None),
@@ -249,54 +274,68 @@ fn parse_text<'arena>(
     arena.alloc(NodeData::Text(RefCell::new(text.text().map(Into::into))))
 }
 
-fn parse_attr_name(attr: roxmltree::Attribute, prefix_map: &HashMap<&str, &str>) -> QualName {
-    if let Some(ns) = attr.namespace() {
-        QualName {
-            prefix: prefix_map.get(ns).map(|prefix| (*prefix).into()),
-            ns: ns.into(),
-            local: attr.name().into(),
-        }
-    } else {
-        QualName {
-            prefix: None,
-            ns: Atom::default(),
-            local: attr.name().into(),
-        }
+fn parse_attr_name(attr: roxmltree::Attribute, namespace_map: &NamespaceMap) -> QualName {
+    let ns = attr.namespace();
+    QualName {
+        prefix: namespace_map
+            .get_by_uri(&ns.map(Into::into))
+            .cloned()
+            .flatten(),
+        ns: ns.map_or_else(
+            || {
+                namespace_map
+                    .get_by_prefix(&None)
+                    .cloned()
+                    .flatten()
+                    .unwrap_or_default()
+                    .as_ref()
+                    .into()
+            },
+            Into::into,
+        ),
+        local: attr.name().into(),
     }
 }
 
 fn parse_expanded_name(
     name: roxmltree::ExpandedName,
-    prefix_map: &HashMap<&str, &str>,
+    namespace_map: &mut NamespaceMap,
 ) -> QualName {
     let ns = name.namespace();
-    let ns = match ns {
-        Some("http://www.w3.org/2000/svg" | "") => None,
-        _ => ns,
-    };
-    if let Some(ns) = ns {
-        QualName {
-            prefix: prefix_map.get(ns).map(|prefix| (*prefix).into()),
-            ns: ns.into(),
-            local: name.name().into(),
-        }
-    } else {
-        QualName {
-            prefix: None,
-            ns: Atom::default(),
-            local: name.name().into(),
-        }
+    QualName {
+        prefix: namespace_map
+            .get_by_uri(&ns.map(Into::into))
+            .cloned()
+            .flatten(),
+        ns: ns.map_or_else(
+            || {
+                namespace_map
+                    .get_by_prefix(&None)
+                    .cloned()
+                    .flatten()
+                    .unwrap_or_default()
+                    .as_ref()
+                    .into()
+            },
+            Into::into,
+        ),
+        local: name.name().into(),
     }
 }
 
+#[allow(clippy::option_option)]
 fn find_new_xmlns(
     ns: &roxmltree::Namespace,
     namespace_map: &mut NamespaceMap,
+    popped_ns: &mut Vec<(Option<Prefix>, Option<StrTendril>)>,
 ) -> Option<Attribute> {
     if (ns.name().is_some() || !ns.uri().is_empty()) && !find_xml_uri(ns, namespace_map) {
         let prefix = ns.name().map(Into::into);
         let uri: StrTendril = ns.uri().into();
-        namespace_map.insert(prefix.clone(), Some(uri.clone()));
+        let popped = namespace_map.insert(prefix.clone(), Some(uri.clone()));
+        if let Some(popped) = popped {
+            popped_ns.push(popped);
+        }
         Some(Attribute {
             name: QualName {
                 local: if let Some(prefix) = prefix.as_ref() {
@@ -315,7 +354,7 @@ fn find_new_xmlns(
 }
 
 fn find_xml_uri(ns: &roxmltree::Namespace, namespace_map: &mut NamespaceMap) -> bool {
-    if let Some(Some(el)) = namespace_map.get(&ns.name().map(Into::into)) {
+    if let Some(Some(el)) = namespace_map.get_by_prefix(&ns.name().map(Into::into)) {
         el.as_ref() == ns.uri()
     } else {
         false

--- a/crates/oxvg_ast/src/implementations/shared.rs
+++ b/crates/oxvg_ast/src/implementations/shared.rs
@@ -662,6 +662,7 @@ impl<'arena> node::Node<'arena> for Ref<'arena> {
     type Child = Ref<'arena>;
     type ParentChild = Ref<'arena>;
     type Parent = Element<'arena>;
+    type Name = QualName;
 
     fn id(&self) -> usize {
         self.id
@@ -974,6 +975,7 @@ impl<'arena> node::Node<'arena> for Element<'arena> {
     type Child = Ref<'arena>;
     type ParentChild = Ref<'arena>;
     type Parent = Element<'arena>;
+    type Name = QualName;
 
     fn id(&self) -> usize {
         self.node.id()
@@ -983,7 +985,8 @@ impl<'arena> node::Node<'arena> for Element<'arena> {
         self.node.child_nodes_iter()
     }
 
-    fn element(&self) -> Option<impl element::Element<'arena>> {
+    #[allow(refining_impl_trait)]
+    fn element(&self) -> Option<Self> {
         Some(self.clone())
     }
 
@@ -1117,7 +1120,6 @@ impl<'arena> node::Node<'arena> for Element<'arena> {
 }
 
 impl<'arena> element::Element<'arena> for Element<'arena> {
-    type Name = QualName;
     type Attributes<'a> = Attributes<'a>;
     type Attr = Attribute;
     type Lifetimed<'a> = Element<'a>;
@@ -1391,7 +1393,7 @@ impl<'arena> document::Document<'arena> for Document<'arena> {
 
     fn create_element(
         &self,
-        tag_name: <Self::Root as element::Element<'arena>>::Name,
+        tag_name: <Self::Root as node::Node<'arena>>::Name,
         arena: &<Self::Root as node::Node<'arena>>::Arena,
     ) -> Self::Root {
         Element::new(arena.alloc(Node::new(

--- a/crates/oxvg_ast/src/implementations/shared.rs
+++ b/crates/oxvg_ast/src/implementations/shared.rs
@@ -26,7 +26,7 @@ pub type Ref<'arena> = &'arena Node<'arena>;
 /// A settable reference to a node
 pub type Link<'arena> = Cell<Option<Ref<'arena>>>;
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
+#[derive(Debug, Clone)]
 /// A qualified name used for the names of tags and attributes.
 pub struct QualName {
     /// The local name (e.g. the `href` of `xlink:href`) of a qualified name.
@@ -35,6 +35,27 @@ pub struct QualName {
     pub prefix: Option<string_cache::Atom<markup5ever::PrefixStaticSet>>,
     /// The resolved uri of the name
     pub ns: string_cache::Atom<markup5ever::NamespaceStaticSet>,
+}
+
+impl PartialEq for QualName {
+    fn eq(&self, other: &Self) -> bool {
+        self.local == other.local && self.prefix == other.prefix
+    }
+}
+impl Eq for QualName {}
+
+impl PartialOrd for QualName {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for QualName {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.local.cmp(&other.local) {
+            std::cmp::Ordering::Equal => self.prefix.cmp(&other.prefix),
+            ord => ord,
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
@@ -151,10 +172,9 @@ impl Name for QualName {
 
 impl std::hash::Hash for QualName {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let Self { prefix, ns, local } = self;
+        let Self { prefix, local, .. } = self;
 
         prefix.hash(state);
-        ns.hash(state);
         local.hash(state);
     }
 }

--- a/crates/oxvg_ast/src/lib.rs
+++ b/crates/oxvg_ast/src/lib.rs
@@ -21,6 +21,8 @@ pub mod visitor;
 
 #[cfg(feature = "serialize")]
 pub mod serialize;
+#[cfg(feature = "serialize")]
+pub mod xmlwriter;
 
 #[cfg(feature = "selectors")]
 pub mod selectors;

--- a/crates/oxvg_ast/src/name.rs
+++ b/crates/oxvg_ast/src/name.rs
@@ -57,9 +57,9 @@ pub trait Name:
 
     /// Calls `f` with a borrowed string, to prevent allocation in the case that
     /// the name doesn't have a prefix
-    fn with_str<F>(&self, mut f: F)
+    fn with_str<F, R>(&self, mut f: F) -> R
     where
-        F: FnMut(&str),
+        F: FnMut(&str) -> R,
     {
         match self.prefix() {
             Some(p) => {

--- a/crates/oxvg_ast/src/node.rs
+++ b/crates/oxvg_ast/src/node.rs
@@ -1,7 +1,7 @@
 //! XML node traits.
 use std::fmt::Debug;
 
-use crate::{atom::Atom, element::Element};
+use crate::{atom::Atom, element::Element, name::Name};
 
 #[derive(PartialEq, Debug)]
 /// An enum which specifies the type of node.
@@ -50,7 +50,15 @@ pub trait Node<'arena>: Clone + Debug {
     /// The node type of the sibling of a node
     type ParentChild: Node<'arena, Atom = Self::Atom, Parent = Self::Parent, Arena = Self::Arena>;
     /// The node type of the parent of a node
-    type Parent: Node<'arena, Atom = Self::Atom, Child = Self::ParentChild, Arena = Self::Arena>;
+    type Parent: Node<
+        'arena,
+        Atom = Self::Atom,
+        Child = Self::ParentChild,
+        Arena = Self::Arena,
+        Name = Self::Name,
+    >;
+    /// The type representing the tag or attribute name of the element
+    type Name: Name;
 
     /// Whether the allocation id is the same address as the other
     fn id_eq(&self, other: &impl Node<'arena>) -> bool {
@@ -74,7 +82,7 @@ pub trait Node<'arena>: Clone + Debug {
     }
 
     /// Upcasts self as an element
-    fn element(&self) -> Option<impl Element<'arena>>;
+    fn element(&self) -> Option<impl Element<'arena, Name = Self::Name>>;
 
     /// Removes all child nodes
     fn empty(&self);

--- a/crates/oxvg_ast/src/selectors.rs
+++ b/crates/oxvg_ast/src/selectors.rs
@@ -369,9 +369,9 @@ impl<'arena, E: element::Element<'arena>> SelectElement<'arena, E> {
 impl<'arena, E: element::Element<'arena>> selectors::Element for SelectElement<'arena, E> {
     type Impl = SelectorImpl<
         <E as node::Node<'arena>>::Atom,
-        <<E as element::Element<'arena>>::Name as Name>::Prefix,
-        <<E as element::Element<'arena>>::Name as Name>::LocalName,
-        <<E as element::Element<'arena>>::Name as Name>::Namespace,
+        <<E as node::Node<'arena>>::Name as Name>::Prefix,
+        <<E as node::Node<'arena>>::Name as Name>::LocalName,
+        <<E as node::Node<'arena>>::Name as Name>::Namespace,
     >;
 
     fn opaque(&self) -> selectors::OpaqueElement {

--- a/crates/oxvg_ast/src/selectors.rs
+++ b/crates/oxvg_ast/src/selectors.rs
@@ -449,6 +449,9 @@ impl<'arena, E: element::Element<'arena>> selectors::Element for SelectElement<'
 
         let value = match ns {
             NamespaceConstraint::Any => self.element.get_attribute_local(&local_name.0),
+            NamespaceConstraint::Specific(ns) if ns.0.is_empty() => {
+                self.element.get_attribute_local(&local_name.0)
+            }
             NamespaceConstraint::Specific(ns) => {
                 self.element.get_attribute_ns(&ns.0, &local_name.0)
             }

--- a/crates/oxvg_ast/src/serialize.rs
+++ b/crates/oxvg_ast/src/serialize.rs
@@ -1,24 +1,13 @@
 //! Funcions for serializing XML trees
 use std::io::Write;
-use std::panic;
 
-use xmlwriter::XmlWriter;
-
-pub use xmlwriter::{Indent, Options};
+use crate::xmlwriter::{Error, XmlWriter};
+pub use crate::xmlwriter::{Indent, Options};
 
 use crate::attribute::{Attr as _, Attributes as _};
 use crate::element::Element as _;
 use crate::name::Name as _;
 use crate::node;
-
-/// A serialization error.
-#[derive(Debug)]
-pub enum Error {
-    /// The serializer panicked while writing the dom to a string.
-    SerializerPanicked,
-    /// The serializer packicked while writing to a writer
-    IO(std::io::Error),
-}
 
 /// An XML node serializer
 pub trait Node<'arena> {
@@ -30,69 +19,67 @@ pub trait Node<'arena> {
 
     /// # Errors
     /// If the serialization or write fails
-    fn serialize_into<W: Write>(&self, mut wr: W, options: Options) -> Result<usize, Error> {
-        wr.write(self.serialize_with_options(options)?.as_bytes())
-            .map_err(Error::IO)
-    }
+    fn serialize_into<W: Write>(&self, wr: W, options: Options) -> Result<W, Error>;
 
     /// # Errors
     /// If the underlying serialization fails
     fn serialize_with_options(&self, options: Options) -> Result<String, Error>;
 }
 
-impl std::error::Error for Error {}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        "The serializer panicked while writing the dom to a string.".fmt(f)
-    }
-}
-
-impl<'arena, T: node::Node<'arena>> Node<'arena> for T {
+impl<'arena, T: node::Node<'arena, Child = T>> Node<'arena> for T {
     fn serialize_with_options(&self, options: Options) -> Result<String, Error> {
-        let mut xml = XmlWriter::new(options);
+        let mut wr = Vec::new();
+        self.serialize_into(&mut wr, options)?;
+        String::from_utf8(wr).map_err(Error::UTF8)
+    }
 
-        serialize_node(self, &mut xml);
+    fn serialize_into<W: Write>(&self, wr: W, options: Options) -> Result<W, Error> {
+        let mut xml = XmlWriter::new(wr, options);
 
-        panic::catch_unwind(|| xml.end_document()).map_err(|_| Error::SerializerPanicked)
+        serialize_node(self, &mut xml)?;
+
+        xml.end_document()
     }
 }
 
-fn serialize_node<'arena, T: node::Node<'arena>>(node: &T, xml: &mut XmlWriter) {
+fn serialize_node<'arena, T: node::Node<'arena, Child = T>, W: Write>(
+    node: &T,
+    xml: &mut XmlWriter<W, T::Name>,
+) -> Result<(), Error> {
     match node.node_type() {
         node::Type::Element => {
             let element = node.element().expect("type of element");
-            element.qual_name().with_str(|s| xml.start_element(s));
+            xml.start_element(element.qual_name().clone())?;
             for attr in element.attributes().into_iter() {
                 attr.name()
-                    .with_str(|s| xml.write_attribute(s, attr.value()));
+                    .with_str(|s| xml.write_attribute(s, attr.value()))?;
             }
         }
         node::Type::Text => {
             if let Some(text) = node.text_content() {
                 let text = text.trim();
                 if !text.is_empty() {
-                    xml.write_text(text);
+                    xml.write_text(text)?;
                 }
             }
         }
         node::Type::Comment => {
-            xml.write_comment(&node.text_content().unwrap_or_default());
+            xml.write_comment(&node.text_content().unwrap_or_default())?;
         }
         node::Type::ProcessingInstruction => {
-            // FIXME: Assuming all declarations are the same, since writer doesn't
-            // support anything custom
-            // let (target, value) = node.processing_instruction().expect("expected pi");
-            xml.write_declaration();
+            let (target, value) = node.processing_instruction().expect("expected pi");
+            xml.write_declaration(&target, &value)?;
         }
         _ => {}
     }
 
     for child in node.child_nodes_iter() {
-        serialize_node(&child, xml);
+        serialize_node(&child, xml)?;
     }
 
     if node.node_type() == node::Type::Element {
-        xml.end_element();
+        xml.end_element()
+    } else {
+        Ok(())
     }
 }

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -48,6 +48,7 @@ use crate::{
     attribute::{Attr, Attributes},
     element::Element,
     name::Name,
+    node,
     selectors::{SelectElement, Selector},
 };
 
@@ -1616,7 +1617,10 @@ pub fn root<'arena, E: Element<'arena>>(root: &E) -> String {
 /// Contains a collection of style data associated with an element
 pub struct ElementData<'arena, E: Element<'arena>> {
     inline_style: Option<E::Atom>,
-    presentation_attrs: Vec<(<<E as Element<'arena>>::Name as Name>::LocalName, E::Atom)>,
+    presentation_attrs: Vec<(
+        <<E as node::Node<'arena>>::Name as Name>::LocalName,
+        E::Atom,
+    )>,
 }
 
 impl<'arena, E: Element<'arena>> Default for ElementData<'arena, E> {

--- a/crates/oxvg_ast/src/xmlwriter.rs
+++ b/crates/oxvg_ast/src/xmlwriter.rs
@@ -1,0 +1,891 @@
+/*!
+
+A copy of the [xmlwriter](https://docs.rs/xmlwriter/latest/xmlwriter/index.html) create, except with some slight modifications.
+
+- Errors instead of panicking
+- Uses our `QualName` instead of storing a reference to `&str`
+- Allows writing custom xml declarations
+
+---
+
+A simple, streaming, partially-validating XML writer that writes XML data to a
+`std::io::Write` implementation.
+
+### Features
+
+- A simple, bare-minimum API that panics when writing invalid XML.
+- Non-allocating API. All methods are accepting either `fmt::Display` or `fmt::Arguments`.
+- Nodes auto-closing.
+
+### Example
+
+```rust
+use oxvg_ast::{xmlwriter::*, name::Name as _, implementations::shared::QualName};
+use std::io;
+
+fn main() -> Result {
+    let opt = Options {
+        use_single_quote: true,
+        ..Options::default()
+    };
+
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element(QualName::new(None, "svg".into()))?;
+    w.write_attribute("xmlns", "http://www.w3.org/2000/svg")?;
+    w.write_attribute_fmt("viewBox", format_args!("{} {} {} {}", 0, 0, 128, 128))?;
+    w.start_element(QualName::new(None, "text".into()))?;
+    // We can write any object that implements `fmt::Display`.
+    w.write_attribute("x", &10)?;
+    w.write_attribute("y", &20)?;
+    w.write_text_fmt(format_args!("length is {}", 5))?;
+
+    assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+        .expect("xmlwriter always writes valid UTF-8"),
+"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'>
+    <text x='10' y='20'>
+        length is 5
+    </text>
+</svg>
+"
+    );
+    Ok(())
+}
+```
+*/
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(missing_copy_implementations)]
+
+use std::fmt::{self, Display, Write as FmtWrite};
+use std::io::{self, Write};
+use std::result;
+
+use crate::atom::Atom;
+use crate::name::Name;
+
+/// A result from serializing a document.
+pub type Result = result::Result<(), Error>;
+
+/// An error while serializing a document.
+#[derive(Debug)]
+pub enum Error {
+    /// An error while running an io operation.
+    IO(io::Error),
+    /// An error while flushing buffer.
+    BufWriter(io::IntoInnerError<io::BufWriter<Vec<u8>>>),
+    /// An error after writing to string.
+    UTF8(std::string::FromUtf8Error),
+    /// Did not have opening element name when closing element.
+    ClosedUnopenedElement,
+    /// Attempted to write attribute before `start_element()` or after `close_element()`.
+    AttributeWrittenBeforeElement,
+    /// Declaration was already written.
+    DeclarationAlreadyWritten,
+    /// Attempts to write text before `start_element()`.
+    TextBeforeElement,
+    /// Attempts to write CDATA with `]]>` in the content.
+    BadCDATA,
+}
+
+/// An XML node indention.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Indent {
+    /// Disable indention and new lines.
+    None,
+    /// Indent with spaces. Preferred range is 0..4.
+    Spaces(u8),
+    /// Indent with tabs.
+    Tabs,
+}
+
+/// An XML writing options.
+#[derive(Clone, Copy, Debug)]
+pub struct Options {
+    /// Use single quote marks instead of double quote.
+    ///
+    /// # Examples
+    ///
+    /// Before:
+    ///
+    /// ```text
+    /// <rect fill="red"/>
+    /// ```
+    ///
+    /// After:
+    ///
+    /// ```text
+    /// <rect fill='red'/>
+    /// ```
+    ///
+    /// Default: disabled
+    pub use_single_quote: bool,
+
+    /// Set XML nodes indention.
+    ///
+    /// # Examples
+    ///
+    /// `Indent::None`
+    /// Before:
+    ///
+    /// ```text
+    /// <svg>
+    ///     <rect fill="red"/>
+    /// </svg>
+    /// ```
+    ///
+    /// After:
+    ///
+    /// ```text
+    /// <svg><rect fill="red"/></svg>
+    /// ```
+    ///
+    /// Default: 4 spaces
+    pub indent: Indent,
+
+    /// Set XML attributes indention.
+    ///
+    /// # Examples
+    ///
+    /// `Indent::Spaces(2)`
+    ///
+    /// Before:
+    ///
+    /// ```text
+    /// <svg>
+    ///     <rect fill="red" stroke="black"/>
+    /// </svg>
+    /// ```
+    ///
+    /// After:
+    ///
+    /// ```text
+    /// <svg>
+    ///     <rect
+    ///       fill="red"
+    ///       stroke="black"/>
+    /// </svg>
+    /// ```
+    ///
+    /// Default: `None`
+    pub attributes_indent: Indent,
+
+    /// Write self-closing tags when element is empty.
+    ///
+    /// # Examples
+    ///
+    /// Before:
+    ///
+    /// ```text
+    /// <tag/>
+    /// ```
+    ///
+    /// After:
+    ///
+    /// ```text
+    /// <tag>
+    /// </tag>
+    /// ```
+    ///
+    /// Default: enabled
+    pub enable_self_closing: bool,
+}
+
+impl Default for Options {
+    #[inline]
+    fn default() -> Self {
+        Options {
+            use_single_quote: false,
+            indent: Indent::Spaces(4),
+            attributes_indent: Indent::None,
+            enable_self_closing: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum State {
+    Empty,
+    Document,
+    Attributes,
+    CData,
+}
+
+#[derive(Clone, Debug)]
+struct DepthData<N: Name> {
+    element_name: Option<N>,
+    has_children: bool,
+}
+
+// This wrapper writer is so that we can make sure formatted strings are properly escaped too,
+// as we don't have access to the formatting stuff without a fmt::Write implementation, so
+// we provide it by wrapping the writer given to us while escaping appropriately any string to
+// be written, depending on the type of node we're writing.
+#[derive(Clone, Debug)]
+struct FmtWriter<W: Write> {
+    writer: W,
+    error_kind: Option<io::ErrorKind>,
+    // Set to None once the text is written, as a way to make sure the code
+    // sets the proper escaping type before using the fmt_writer.write_str().
+    escape: Option<Escape>,
+    // Same as for Options, but kept available for write_escaped()
+    use_single_quote: bool,
+}
+
+impl<W: Write> FmtWriter<W> {
+    fn take_err(&mut self) -> Error {
+        let error_kind = self
+            .error_kind
+            .expect("there must have been an error before calling take_err()!");
+        // This avoids forgetting to set it to the appropriate value when calling write_fmt().
+        // We can't do it in FmtWriter's write_str(), since with a real format string the method
+        // will be called several times so it'll fail in the expect() below as we'll have set
+        // self.escape back to None.
+        self.escape = None;
+        // Make sure we can detect if take_err() is called without having an error that happened beforehand
+        self.error_kind = None;
+
+        // There's just no way of properly copying the io::Error (no Copy or Clone available), so
+        // we have no choice to create a new one, which likely loses the backtrace up to this point.
+        Error::IO(io::Error::from(error_kind))
+    }
+
+    fn write_escaped(&mut self, s: &str, escape_quotes: bool) -> io::Result<()> {
+        let mut part_start_pos = 0;
+        for (byte_pos, byte) in s.bytes().enumerate() {
+            let escaped_char: Option<&[u8]> = match byte {
+                b'&' => Some(b"&amp;"),
+                b'>' => Some(b"&gt;"),
+                b'<' => Some(b"&lt;"),
+                b'"' if escape_quotes && !self.use_single_quote => Some(b"&quot;"),
+                b'\'' if escape_quotes && self.use_single_quote => Some(b"&apos;"),
+                _ => None,
+            };
+            if let Some(escaped_char) = escaped_char {
+                // We have a character to escape, so write the previous part and the escaped character
+                self.writer
+                    .write_all(s[part_start_pos..byte_pos].as_bytes())?;
+                self.writer.write_all(escaped_char)?;
+                // +1 skips the escaped character from part, for afterwards
+                part_start_pos = byte_pos + 1;
+            }
+            // There's nothing to be done if the character doesn't need to be escaped, as we'll either
+            // wait until we get an escapable character, or wait until the end of the string where we'll
+            // just write out the rest of the string.
+        }
+        // Write the rest of the string which needs no escaping
+        self.writer.write_all(s[part_start_pos..].as_bytes())
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Escape {
+    Comment,
+    AttributeValue,
+    Text,
+    CData,
+}
+
+impl<W: Write> fmt::Write for FmtWriter<W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let error = match self
+            .escape
+            .expect("You must have set self.escape to Some(…) before using the formatter!")
+        {
+            Escape::AttributeValue => self.write_escaped(s, true),
+            Escape::Text => self.write_escaped(s, false),
+            // We don't bother escaping double hyphen (--) in comment as it's
+            // unlikely to ever happen, and even libxml2 does not do it.
+            Escape::Comment | Escape::CData => self.writer.write_all(s.as_bytes()),
+        };
+        if error.is_err() {
+            self.error_kind = Some(error.as_ref().unwrap_err().kind());
+            Err(fmt::Error)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// An XML writer.
+#[derive(Clone, Debug)]
+pub struct XmlWriter<W: Write, N: Name> {
+    // When you control what you're writing enough that you know the bytes are already escaped or
+    // don't need escaping at all, then use fmt_writer.writer.write_all()?; directly. Otherwise,
+    // set fmt_writer.escape to the appropriate escaping type and use fmt_writer.write_fmt()?; or
+    // fmt_writer.write_str()?; if you are only printing a string directly without formatting, but
+    // still want escaping to be done.
+    fmt_writer: FmtWriter<W>,
+    state: State,
+    preserve_whitespaces: bool,
+    depth_stack: Vec<DepthData<N>>,
+    opt: Options,
+}
+
+impl<W: Write, N: Name> XmlWriter<W, N> {
+    /// Creates a new `XmlWriter`, writing data in the writer.
+    #[inline]
+    pub fn new(writer: W, opt: Options) -> Self {
+        XmlWriter {
+            fmt_writer: FmtWriter {
+                writer,
+                error_kind: None,
+                escape: None,
+                use_single_quote: opt.use_single_quote,
+            },
+            state: State::Empty,
+            preserve_whitespaces: false,
+            depth_stack: Vec::new(),
+            opt,
+        }
+    }
+
+    /// Writes an XML declaration.
+    ///
+    /// `<?xml version="1.0" encoding="UTF-8" standalone="no"?>`
+    ///
+    /// # Errors
+    ///
+    /// - When called twice.
+    #[inline(never)]
+    pub fn write_declaration<T: Atom, V: Atom>(&mut self, target: &T, value: &V) -> Result {
+        if self.state != State::Empty {
+            return Err(Error::DeclarationAlreadyWritten);
+        }
+
+        self.fmt_writer
+            .writer
+            .write_fmt(format_args!("<?{target} {value}?>"))
+            .map_err(Error::IO)?;
+        self.state = State::Document;
+
+        Ok(())
+    }
+
+    /// Writes a comment string.
+    ///
+    /// # Errors
+    ///
+    /// When comment is in a bad state or when io fails.
+    pub fn write_comment(&mut self, text: &str) -> Result {
+        self.write_comment_fmt(format_args!("{text}"))
+    }
+
+    /// Writes a formatted comment. Forbidden double hyphens will be escaped.
+    ///
+    /// # Errors
+    ///
+    /// When comment is in a bad state or when io fails.
+    #[inline(never)]
+    pub fn write_comment_fmt(&mut self, fmt: fmt::Arguments) -> Result {
+        if self.state == State::Attributes {
+            self.write_open_element()?;
+        }
+
+        if self.state != State::Empty {
+            self.write_new_line()?;
+        }
+
+        self.write_node_indent()?;
+
+        // <!--text-->
+        self.fmt_writer
+            .writer
+            .write_all(b"<!--")
+            .map_err(Error::IO)?;
+        self.fmt_writer.escape = Some(Escape::Comment);
+        self.fmt_writer
+            .write_fmt(fmt)
+            .map_err(|_| self.fmt_writer.take_err())?;
+        self.fmt_writer
+            .writer
+            .write_all(b"-->")
+            .map_err(Error::IO)?;
+
+        if self.state == State::Attributes {
+            self.depth_stack.push(DepthData {
+                element_name: None,
+                has_children: false,
+            });
+        }
+
+        self.state = State::Document;
+
+        Ok(())
+    }
+
+    /// Starts writing a new element.
+    ///
+    /// This method writes only the `<tag-name` part.
+    ///
+    /// # Errors
+    ///
+    /// When in a bad state or when io fails.
+    #[inline(never)]
+    pub fn start_element(&mut self, name: N) -> Result {
+        if self.state == State::Attributes {
+            self.write_open_element()?;
+        }
+
+        if self.state != State::Empty {
+            self.write_new_line()?;
+        }
+
+        if !self.preserve_whitespaces {
+            self.write_node_indent()?;
+        }
+
+        self.fmt_writer.writer.write_all(b"<").map_err(Error::IO)?;
+        self.fmt_writer
+            .writer
+            .write_fmt(format_args!("{}", name.formatter()))
+            .map_err(Error::IO)?;
+
+        self.depth_stack.push(DepthData {
+            element_name: Some(name),
+            has_children: false,
+        });
+
+        self.state = State::Attributes;
+
+        Ok(())
+    }
+
+    /// Writes an attribute.
+    ///
+    /// Any occurrence of `&<>"'` in the value will be escaped.
+    ///
+    /// # Errors
+    ///
+    /// - When called before `start_element()`.
+    /// - When called after `close_element()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use oxvg_ast::{
+    ///     xmlwriter::*,
+    ///     name::Name as _,
+    ///     implementations::shared::QualName,
+    /// };
+    /// use std::io;
+    ///
+    /// fn main() -> Result {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element(QualName::new(None, "svg".into()))?;
+    ///     w.write_attribute("x", "5")?;
+    ///     w.write_attribute("y", &5)?;
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
+    ///         "<svg x=\"5\" y=\"5\"/>\n",
+    ///     );
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn write_attribute<V: Display + ?Sized>(&mut self, name: &str, value: &V) -> Result {
+        self.write_attribute_fmt(name, format_args!("{value}"))
+    }
+
+    /// Writes a formatted attribute value.
+    ///
+    /// Any occurrence of `&<>"'` in the value will be escaped.
+    ///
+    /// # Errors
+    ///
+    /// - When called before `start_element()`.
+    /// - When called after `close_element()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use oxvg_ast::{
+    ///     xmlwriter::*,
+    ///     name::Name as _,
+    ///     implementations::shared::QualName,
+    /// };
+    /// use std::io;
+    ///
+    /// fn main() -> Result {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element(QualName::new(None, "rect".into()))?;
+    ///     w.write_attribute_fmt("fill", format_args!("url(#{})", "gradient"))?;
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
+    ///         "<rect fill=\"url(#gradient)\"/>\n"
+    ///     );
+    ///     Ok(())
+    /// }
+    /// ```
+    #[inline(never)]
+    pub fn write_attribute_fmt(&mut self, name: &str, fmt: fmt::Arguments) -> Result {
+        if self.state != State::Attributes {
+            return Err(Error::AttributeWrittenBeforeElement);
+        }
+
+        self.write_attribute_prefix(name).map_err(Error::IO)?;
+        self.fmt_writer.escape = Some(Escape::AttributeValue);
+        self.fmt_writer
+            .write_fmt(fmt)
+            .map_err(|_| self.fmt_writer.take_err())?;
+        self.write_quote().map_err(Error::IO)
+    }
+
+    /// Writes a raw attribute value, without performing escaping.
+    ///
+    /// Closure provides a mutable reference to the writer.
+    ///
+    /// **Warning:** this method is an escape hatch for cases when you need to write
+    /// a lot of data very fast, and as such does no validity checks whatsoever on the
+    /// written value.
+    ///
+    /// # Errors
+    ///
+    /// - When called before `start_element()`.
+    /// - When called after `close_element()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use oxvg_ast::{
+    ///     xmlwriter::*,
+    ///     name::Name as _,
+    ///     implementations::shared::QualName,
+    /// };
+    /// use std::io::{self, Write};
+    ///
+    /// fn main() -> Result {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element(QualName::new(None, "path".into()));
+    ///     w.write_attribute_raw("d", |writer| writer.write_all(b"M 10 20 L 30 40") );
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
+    ///         "<path d=\"M 10 20 L 30 40\"/>\n"
+    ///     );
+    ///     Ok(())
+    /// }
+    /// ```
+    #[inline(never)]
+    pub fn write_attribute_raw<F>(&mut self, name: &str, f: F) -> Result
+    where
+        F: FnOnce(&mut W) -> io::Result<()>,
+    {
+        if self.state != State::Attributes {
+            return Err(Error::AttributeWrittenBeforeElement);
+        }
+
+        self.write_attribute_prefix(name).map_err(Error::IO)?;
+        f(&mut self.fmt_writer.writer).map_err(Error::IO)?;
+        self.write_quote().map_err(Error::IO)
+    }
+
+    #[inline(never)]
+    fn write_attribute_prefix(&mut self, name: &str) -> io::Result<()> {
+        if self.opt.attributes_indent == Indent::None {
+            self.fmt_writer.writer.write_all(b" ")?;
+        } else {
+            self.fmt_writer.writer.write_all(b"\n")?;
+
+            let depth = self.depth_stack.len();
+            if depth > 0 {
+                self.write_indent(depth - 1, self.opt.indent)?;
+            }
+
+            self.write_indent(1, self.opt.attributes_indent)?;
+        }
+
+        self.fmt_writer.writer.write_all(name.as_bytes())?;
+        self.fmt_writer.writer.write_all(b"=")?;
+        self.write_quote()
+    }
+
+    /// Sets the preserve whitespaces flag.
+    ///
+    /// - If set, text nodes will be written as is.
+    /// - If not set, text nodes will be indented.
+    ///
+    /// Can be set at any moment.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use oxvg_ast::{
+    ///     xmlwriter::*,
+    ///     name::Name as _,
+    ///     implementations::shared::QualName,
+    /// };
+    /// use std::io;
+    ///
+    /// fn main() -> Result {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element(QualName::new(None, "html".into()))?;
+    ///     w.start_element(QualName::new(None, "p".into()))?;
+    ///     w.write_text("text".into())?;
+    ///     w.end_element()?;
+    ///     w.start_element(QualName::new(None, "p".into()))?;
+    ///     w.set_preserve_whitespaces(true);
+    ///     w.write_text("text".into())?;
+    ///     w.end_element()?;
+    ///     w.set_preserve_whitespaces(false);
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should produce valid UTF-8"),
+    /// "<html>
+    ///     <p>
+    ///         text
+    ///     </p>
+    ///     <p>text</p>
+    /// </html>
+    /// "
+    ///     );
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn set_preserve_whitespaces(&mut self, preserve: bool) {
+        self.preserve_whitespaces = preserve;
+    }
+
+    /// Writes a text node.
+    ///
+    /// See [`write_text_fmt()`] for details.
+    ///
+    /// [`write_text_fmt()`]: struct.XmlWriter.html#method.write_text_fmt
+    ///
+    /// # Errors
+    ///
+    /// - When called not after `start_element()`.
+    pub fn write_text<T: Display + ?Sized>(&mut self, text: &T) -> Result {
+        self.write_text_fmt(format_args!("{text}"))
+    }
+
+    /// Writes a formatted text node.
+    ///
+    /// `><&` will be escaped.
+    ///
+    /// # Errors
+    ///
+    /// - When called not after `start_element()`.
+    pub fn write_text_fmt(&mut self, fmt: fmt::Arguments) -> Result {
+        self.write_text_fmt_impl(fmt, false)
+    }
+
+    /// Writes text inside a `<![CDATA[ ... ]]>` node.
+    ///
+    /// # Errors
+    ///
+    /// - When called not after `start_element()`.
+    /// - When the text contains the literal `]]>`.
+    pub fn write_cdata_text(&mut self, text: &str) -> Result {
+        if text.contains("]]>") {
+            return Err(Error::BadCDATA);
+        }
+        self.write_text_fmt_impl(format_args!("{text}"), true)
+    }
+
+    #[inline(never)]
+    fn write_text_fmt_impl(&mut self, fmt: fmt::Arguments, cdata: bool) -> Result {
+        if self.state == State::Empty || self.depth_stack.is_empty() {
+            return Err(Error::TextBeforeElement);
+        }
+
+        if self.state == State::Attributes {
+            self.write_open_element()?;
+        }
+
+        if cdata && self.state != State::CData {
+            self.fmt_writer
+                .writer
+                .write_all(b"<![CDATA[")
+                .map_err(Error::IO)?;
+        }
+
+        if self.state != State::Empty {
+            self.write_new_line()?;
+        }
+
+        self.write_node_indent()?;
+
+        self.fmt_writer.escape = Some(if cdata { Escape::CData } else { Escape::Text });
+        self.fmt_writer
+            .write_fmt(fmt)
+            .map_err(|_| self.fmt_writer.take_err())?;
+
+        if self.state == State::Attributes {
+            self.depth_stack.push(DepthData {
+                element_name: None,
+                has_children: false,
+            });
+        }
+
+        self.state = if cdata { State::CData } else { State::Document };
+
+        Ok(())
+    }
+
+    /// Closes an open element.
+    ///
+    /// # Errors
+    ///
+    /// When in a bad state or when io fails.
+    #[inline(never)]
+    pub fn end_element(&mut self) -> Result {
+        if let Some(depth) = self.depth_stack.pop() {
+            if depth.has_children || !self.opt.enable_self_closing {
+                // Close the empty node here as there were no children to close it.
+                if !depth.has_children && !self.opt.enable_self_closing {
+                    self.fmt_writer.writer.write_all(b">").map_err(Error::IO)?;
+                }
+
+                if !self.preserve_whitespaces {
+                    self.write_new_line()?;
+                    self.write_node_indent()?;
+                }
+
+                if self.state == State::CData {
+                    self.fmt_writer
+                        .writer
+                        .write_all(b"]]>")
+                        .map_err(Error::IO)?;
+                }
+
+                self.fmt_writer.writer.write_all(b"</").map_err(Error::IO)?;
+
+                // Write the previous opening element name as closing element now.
+                let Some(element_name) = depth.element_name else {
+                    return Err(Error::ClosedUnopenedElement);
+                };
+                self.fmt_writer
+                    .writer
+                    .write_fmt(format_args!("{}", element_name.formatter()))
+                    .map_err(Error::IO)?;
+
+                self.fmt_writer.writer.write_all(b">").map_err(Error::IO)?;
+            } else {
+                self.fmt_writer.writer.write_all(b"/>").map_err(Error::IO)?;
+            }
+        }
+
+        self.state = State::Document;
+
+        Ok(())
+    }
+
+    /// Closes all open elements and returns back the writer.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use oxvg_ast::{
+    ///     xmlwriter::*,
+    ///     name::Name as _,
+    ///     implementations::shared::QualName,
+    /// };
+    /// use std::io;
+    ///
+    /// fn main() -> Result {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element(QualName::new(None, "svg".into()))?;
+    ///     w.start_element(QualName::new(None, "g".into()))?;
+    ///     w.start_element(QualName::new(None, "rect".into()))?;
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
+    /// "<svg>
+    ///     <g>
+    ///         <rect/>
+    ///     </g>
+    /// </svg>
+    /// "
+    ///     );
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// When in a bad state or when io fails.
+    pub fn end_document(mut self) -> result::Result<W, Error> {
+        while !self.depth_stack.is_empty() {
+            self.end_element()?;
+        }
+
+        self.write_new_line()?;
+
+        Ok(self.fmt_writer.writer)
+    }
+
+    #[inline]
+    fn get_quote_char(&self) -> u8 {
+        if self.opt.use_single_quote {
+            b'\''
+        } else {
+            b'"'
+        }
+    }
+
+    // Writes quote unescaped, so only use when appropriate.
+    #[inline]
+    fn write_quote(&mut self) -> io::Result<()> {
+        self.fmt_writer.writer.write_all(&[self.get_quote_char()])
+    }
+
+    // Writes the end of the current opening element, so `>`.
+    fn write_open_element(&mut self) -> Result {
+        if let Some(depth) = self.depth_stack.last_mut() {
+            depth.has_children = true;
+            self.fmt_writer.writer.write_all(b">").map_err(Error::IO)?;
+
+            self.state = State::Document;
+        }
+        Ok(())
+    }
+
+    fn write_node_indent(&mut self) -> Result {
+        self.write_indent(self.depth_stack.len(), self.opt.indent)
+            .map_err(Error::IO)
+    }
+
+    fn write_indent(&mut self, depth: usize, indent: Indent) -> io::Result<()> {
+        if indent == Indent::None || self.preserve_whitespaces {
+            return Ok(());
+        }
+
+        for _ in 0..depth {
+            match indent {
+                Indent::None => {}
+                Indent::Spaces(n) => {
+                    for _ in 0..n {
+                        self.fmt_writer.writer.write_all(b" ")?;
+                    }
+                }
+                Indent::Tabs => self.fmt_writer.writer.write_all(b"\t")?,
+            }
+        }
+        Ok(())
+    }
+
+    fn write_new_line(&mut self) -> Result {
+        if self.opt.indent != Indent::None && !self.preserve_whitespaces {
+            self.fmt_writer.writer.write_all(b"\n").map_err(Error::IO)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IO(err) => err.fmt(f),
+            Self::BufWriter(err) => err.fmt(f),
+            Self::UTF8(err) => err.fmt(f),
+            Self::ClosedUnopenedElement => {
+                "Did not have opening element name when closing element.".fmt(f)
+            }
+            Self::AttributeWrittenBeforeElement => {
+                "Attempted to write attribute before `start_element()` or after `close_element()`."
+                    .fmt(f)
+            }
+            Self::TextBeforeElement => "Attempts to write text before `start_element()`.".fmt(f),
+            Self::BadCDATA => "Attempts to write CDATA with `]]>` in the content.".fmt(f),
+            Self::DeclarationAlreadyWritten => "Declaration was already written.".fmt(f),
+        }
+    }
+}
+impl std::error::Error for Error {}

--- a/crates/oxvg_optimiser/benches/default_jobs.rs
+++ b/crates/oxvg_optimiser/benches/default_jobs.rs
@@ -33,7 +33,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     for _ in 0..iters {
                         let arena = typed_arena::Arena::new();
                         let dom = parse(svg, &arena).unwrap();
-                        let jobs = Jobs::default();
+                        let mut jobs = Jobs::default();
                         let info = &Info::<Element>::new(&arena);
                         let start = Instant::now();
                         let _ = black_box(jobs.run(&dom, info));

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_attributes__cleanup_attributes-2.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_attributes__cleanup_attributes-2.snap
@@ -4,5 +4,5 @@ expression: "test_config(r#\"{ \"cleanupAttributes\": {\n            \"newlines\
 ---
 <svg xmlns="http://www.w3.org/2000/svg" attr="a b">
     <!-- Should remove all unnecessary whitespace from attributes -->
-    test & &lt;& > ' " &
+    test &amp; &lt;&amp; &gt; ' " &amp;
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-3.snap
@@ -4,7 +4,7 @@ expression: "test_config(r#\"{ \"minifyStyles\": {} }\"#,\nSome(r#\"<svg id=\"te
 ---
 <svg xmlns="http://www.w3.org/2000/svg" id="test" viewBox="0 0 100 100">
     <style>
-        .st0{fill:red;background-image:url("data:image/svg,&lt;svg width=\"16\" height=\"16\"/>");padding:1em}@media screen and (width&lt;=200px){.st0{display:none}}
+        .st0{fill:red;background-image:url("data:image/svg,&lt;svg width=\"16\" height=\"16\"/&gt;");padding:1em}@media screen and (width&lt;=200px){.st0{display:none}}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3px;margin:1em"/>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_xml_proc_inst__remove_xml_proc_inst-2.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_xml_proc_inst__remove_xml_proc_inst-2.snap
@@ -2,7 +2,7 @@
 source: crates/oxvg_optimiser/src/jobs/remove_xml_proc_inst.rs
 expression: "test_config(r#\"{ \"removeXmlProcInst\": true }\"#,\nSome(r#\"<?xml-stylesheet href=\"style.css\" type=\"text/css\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\">\n    test\n</svg>\"#),)?"
 ---
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml-stylesheet href="style.css" type="text/css"?>
 <svg xmlns="http://www.w3.org/2000/svg">
     test
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__sort_attrs__sort_attrs-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__sort_attrs__sort_attrs-3.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/oxvg_optimiser/src/jobs/sort_attrs.rs
-expression: "test_config(r#\"{ \"sortAttrs\": {} }\"#,\nSome(r#\"<svg xmlns:editor2=\"link2\" fill=\"\" b=\"\" xmlns:xlink=\"\" xmlns:editor1=\"link1\" xmlns=\"\" d=\"\">\n    <!-- put xmlns and namespace attributes before others by default -->\n    <rect editor2:b=\"\" editor1:b=\"\" editor2:a=\"\" editor1:a=\"\" />\n</svg>\"#),)?"
+expression: "test_config(r#\"{ \"sortAttrs\": {} }\"#,\nSome(r#\"<svg xmlns:editor2=\"link2\" fill=\"\" b=\"\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:editor1=\"link1\" xmlns=\"\" d=\"\">\n    <!-- put xmlns and namespace attributes before others by default -->\n    <rect editor2:b=\"\" editor1:b=\"\" editor2:a=\"\" editor1:a=\"\" />\n</svg>\"#),)?"
 ---
-<svg xmlns:editor1="link1" xmlns:editor2="link2" xmlns:xlink="" fill="" d="" b="">
+<svg xmlns:editor1="link1" xmlns:editor2="link2" xmlns:xlink="http://www.w3.org/1999/xlink" fill="" d="" b="">
     <!-- put xmlns and namespace attributes before others by default -->
     <rect editor1:a="" editor2:a="" editor1:b="" editor2:b=""/>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
@@ -80,18 +80,16 @@ fn sort_attrs() -> anyhow::Result<()> {
         ),
     )?);
 
-    // FIXME: rcdom is breaking this
     insta::assert_snapshot!(test_config(
         r#"{ "sortAttrs": {} }"#,
         Some(
-            r#"<svg xmlns:editor2="link2" fill="" b="" xmlns:xlink="" xmlns:editor1="link1" xmlns="" d="">
+            r#"<svg xmlns:editor2="link2" fill="" b="" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:editor1="link1" xmlns="" d="">
     <!-- put xmlns and namespace attributes before others by default -->
     <rect editor2:b="" editor1:b="" editor2:a="" editor1:a="" />
 </svg>"#
         ),
     )?);
 
-    // FIXME: rcdom is breaking this
     insta::assert_snapshot!(test_config(
         r#"{ "sortAttrs": { "xmlnsOrder": "alphabetical" } }"#,
         Some(

--- a/packages/correctness/package.json
+++ b/packages/correctness/package.json
@@ -10,11 +10,15 @@
     "optimise:oxygen": "cargo run optimise -r -. -o oxygen-optimised oxygen",
     "optimise:w3c:none": "cargo run optimise --extends none -r -. -o w3c-none w3c",
     "optimise:oxygen:none": "cargo run optimise --extends none -r -. -o oxygen-none oxygen",
+    "optimise:w3c:safe": "cargo run optimise --extends safe -r -. -o w3c-safe w3c",
+    "optimise:oxygen:safe": "cargo run optimise --extends safe -r -. -o oxygen-safe oxygen",
     "compare": "pnpm run compare:w3c",
     "compare:w3c": "node index.js 512 w3c w3c-optimised",
     "compare:oxygen": "node index.js 512 oxygen oxygen-optimised",
     "compare:w3c:none": "node index.js 512 w3c w3c-none",
-    "compare:oxygen:none": "node index.js 512 oxygen oxygen-none"
+    "compare:oxygen:none": "node index.js 512 oxygen oxygen-none",
+    "compare:w3c:safe": "node index.js 512 w3c w3c-safe",
+    "compare:oxygen:safe": "node index.js 512 oxygen oxygen-safe"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Creates a module copying xmlwriter with a modified implementation

- Errors instead of panicking
- Uses our `QualName` instead of storing a reference to `&str`
- Allows writing custom xml declarations
- Some other parsing and ast fixes

This gets us to 100% passing for all testable w3c tests when running with `none` preset.

Closes #125