### PR TITLE
fix: change the mutability of visitors

### DIFF
--- a/crates/oxvg/src/optimise.rs
+++ b/crates/oxvg/src/optimise.rs
@@ -110,7 +110,7 @@ impl Optimise {
     }
 
     fn handle_file<'arena>(
-        jobs: &mut Jobs,
+        jobs: &Jobs,
         path: &PathBuf,
         output: Option<&PathBuf>,
         arena: Arena<'arena>,
@@ -182,8 +182,7 @@ impl Optimise {
                     let Ok(output_path) = output_path(&path) else {
                         return WalkState::Continue;
                     };
-                    if let Err(err) =
-                        Self::handle_file(&mut jobs.clone(), &path, output_path.as_ref(), &arena)
+                    if let Err(err) = Self::handle_file(&jobs, &path, output_path.as_ref(), &arena)
                     {
                         eprintln!(
                             "{}: \x1b[31m{err}\x1b[0m",

--- a/crates/oxvg_optimiser/benches/default_jobs.rs
+++ b/crates/oxvg_optimiser/benches/default_jobs.rs
@@ -33,7 +33,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     for _ in 0..iters {
                         let arena = typed_arena::Arena::new();
                         let dom = parse(svg, &arena).unwrap();
-                        let mut jobs = Jobs::default();
+                        let jobs = Jobs::default();
                         let info = &Info::<Element>::new(&arena);
                         let start = Instant::now();
                         let _ = black_box(jobs.run(&dom, info));

--- a/crates/oxvg_optimiser/benches/path.rs
+++ b/crates/oxvg_optimiser/benches/path.rs
@@ -35,10 +35,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         let arena = typed_arena::Arena::new();
                         let dom = parse(svg, &arena).unwrap();
                         let mut root = Element::from_parent(dom).unwrap();
-                        let mut job = ConvertPathData::default();
+                        let job = ConvertPathData::default();
                         let info = &Info::new(&arena);
                         let start = Instant::now();
-                        let _ = black_box(job.start(&mut root, info));
+                        let _ = black_box(job.start(&mut root, info, None));
                         result += start.elapsed();
                     }
                     result

--- a/crates/oxvg_optimiser/src/jobs/add_attributes_to_svg_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/add_attributes_to_svg_element.rs
@@ -18,7 +18,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for AddAttributesToSVGElemen
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/add_classes_to_svg.rs
+++ b/crates/oxvg_optimiser/src/jobs/add_classes_to_svg.rs
@@ -20,7 +20,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for AddClassesToSVG {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
+++ b/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
@@ -17,7 +17,7 @@ use oxvg_ast::{
     element::Element,
     get_computed_styles_factory,
     style::{self, ComputedStyles, Id, PresentationAttr, PresentationAttrId, Static, Style},
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::{collections, regex::REFERENCES_URL};
 use oxvg_path::{command::Data, convert, Path};
@@ -34,16 +34,21 @@ pub struct ApplyTransforms {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ApplyTransforms {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        PrepareOutcome::use_style
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(PrepareOutcome::use_style)
     }
 
-    fn use_style(&mut self, element: &E) -> bool {
+    fn use_style(&self, element: &E) -> bool {
         element.get_attribute_local(&"d".into()).is_some()
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_attributes.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_attributes.rs
@@ -18,7 +18,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for CleanupAttributes {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
@@ -34,7 +34,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for CleanupListOfValues {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
@@ -34,7 +34,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for CleanupNumericValues {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
+++ b/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
@@ -7,7 +7,7 @@ use oxvg_ast::{
     attribute::{Attr, Attributes},
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::{ElementGroup, Group, INHERITABLE_ATTRS};
 use serde::{Deserialize, Serialize};
@@ -19,16 +19,21 @@ pub struct CollapseGroups(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for CollapseGroups {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn exit_element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/convert_colors.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_colors.rs
@@ -16,7 +16,7 @@ use oxvg_ast::{
     attribute::{Attr, Attributes},
     element::Element,
     style::{PresentationAttr, UnparsedPresentationAttr},
-    visitor::{Context, PrepareOutcome, Visitor},
+    visitor::{Context, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -64,8 +64,13 @@ pub struct ConvertColors {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertColors {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        match self.method {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(match self.method {
             Some(Method::Value {
                 names_2_hex,
                 rgb_2_hex,
@@ -81,11 +86,11 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertColors {
                 }
             }
             _ => PrepareOutcome::none,
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
@@ -1,6 +1,6 @@
 use oxvg_ast::{
     element::Element,
-    visitor::{Context, PrepareOutcome, Visitor},
+    visitor::{Context, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -13,17 +13,22 @@ pub struct ConvertEllipseToCircle(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertEllipseToCircle {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     #[allow(clippy::similar_names)]
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
@@ -1,6 +1,6 @@
 use oxvg_ast::{
     element::Element,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_path::{convert, geometry::MakeArcs, Path};
 use serde::{Deserialize, Serialize};
@@ -69,17 +69,22 @@ pub struct Precision(pub oxvg_path::convert::Precision);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertPathData {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        PrepareOutcome::use_style
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(PrepareOutcome::use_style)
     }
 
-    fn use_style(&mut self, element: &E) -> bool {
+    fn use_style(&self, element: &E) -> bool {
         let d_name = "d".into();
         element.has_attribute_local(&d_name)
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {
@@ -118,8 +123,8 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertPathData {
     }
 }
 
-impl From<&mut ConvertPathData> for convert::Flags {
-    fn from(val: &mut ConvertPathData) -> Self {
+impl From<&ConvertPathData> for convert::Flags {
+    fn from(val: &ConvertPathData) -> Self {
         use convert::Flags;
 
         let mut output = convert::Flags::default();

--- a/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
@@ -21,7 +21,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertShapeToPath {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/convert_transform.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_transform.rs
@@ -10,7 +10,7 @@ use oxvg_ast::{
         Id, Precision, PresentationAttr, PresentationAttrId, SVGTransform, SVGTransformList,
         Static, Style,
     },
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -43,11 +43,16 @@ struct Inner {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertTransform {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        PrepareOutcome::use_style
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(PrepareOutcome::use_style)
     }
 
-    fn use_style(&mut self, element: &E) -> bool {
+    fn use_style(&self, element: &E) -> bool {
         element.attributes().into_iter().any(|attr| {
             matches!(
                 attr.local_name().as_ref(),
@@ -57,7 +62,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for ConvertTransform {
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/merge_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_paths.rs
@@ -11,7 +11,7 @@ use oxvg_ast::{
     element::Element,
     get_computed_property_factory, get_computed_styles_factory,
     style::{ComputedStyles, Id, PresentationAttr, PresentationAttrId, Static},
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_path::{command, Path};
 use serde::{Deserialize, Serialize};
@@ -34,13 +34,18 @@ impl Default for MergePaths {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for MergePaths {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        PrepareOutcome::use_style
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(PrepareOutcome::use_style)
     }
 
     #[allow(clippy::too_many_lines)]
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -35,10 +35,10 @@ macro_rules! jobs {
 
         impl Jobs {
             /// Runs each job in the config, returning the number of non-skipped jobs
-            fn run_jobs<'arena, E: Element<'arena>>(&mut self, element: &mut E, info: &Info<'arena, E>) -> Result<usize, String> {
+            fn run_jobs<'arena, E: Element<'arena>>(&self, element: &mut E, info: &Info<'arena, E>) -> Result<usize, String> {
                 let mut count = 0;
-                $(if let Some(job) = self.$name.as_mut() {
-                    if !job.start(element, info)?.contains(PrepareOutcome::skip) {
+                $(if let Some(job) = self.$name.as_ref() {
+                    if !job.start(element, info, None)?.contains(PrepareOutcome::skip) {
                         count += 1;
                     }
                 })+
@@ -151,7 +151,7 @@ impl Jobs {
     /// # Errors
     /// When any job fails for the first time
     pub fn run<'arena, E: Element<'arena>>(
-        &mut self,
+        &self,
         root: &E::ParentChild,
         info: &Info<'arena, E>,
     ) -> Result<(), Error> {

--- a/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
@@ -4,7 +4,7 @@ use oxvg_ast::{
     attribute::{Attr, Attributes},
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::{INHERITABLE_ATTRS, PATH_ELEMS};
 use serde::{Deserialize, Serialize};
@@ -16,17 +16,24 @@ pub struct MoveElemsAttrsToGroup(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for MoveElemsAttrsToGroup {
     type Error = String;
 
-    fn prepare(&mut self, document: &E, context_flags: &mut ContextFlags) -> PrepareOutcome {
+    fn prepare(
+        &self,
+        document: &E,
+        _info: &Info<'arena, E>,
+        context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
         context_flags.query_has_stylesheet(document);
-        if self.0 && !context_flags.contains(ContextFlags::has_stylesheet) {
-            PrepareOutcome::none
-        } else {
-            PrepareOutcome::skip
-        }
+        Ok(
+            if self.0 && !context_flags.contains(ContextFlags::has_stylesheet) {
+                PrepareOutcome::none
+            } else {
+                PrepareOutcome::skip
+            },
+        )
     }
 
     fn exit_element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
@@ -2,7 +2,7 @@ use oxvg_ast::{
     attribute::{Attr, Attributes},
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::{
     collections::{PATH_ELEMS, REFERENCES_PROPS},
@@ -17,16 +17,21 @@ pub struct MoveGroupAttrsToElems(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for MoveGroupAttrsToElems {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/precheck.rs
+++ b/crates/oxvg_optimiser/src/jobs/precheck.rs
@@ -2,7 +2,6 @@ use oxvg_ast::{
     attribute::{Attr, Attributes},
     element::Element,
     name::Name,
-    node::{self, Node},
     visitor::Visitor,
 };
 use oxvg_collections::collections::{ANIMATION_EVENT, DOCUMENT_EVENT, GRAPHICAL_EVENT};
@@ -26,7 +25,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for Precheck {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut oxvg_ast::visitor::Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
@@ -83,16 +83,21 @@ struct CssVisitor<'arena, 'a, 'b, E: Element<'arena>> {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for PrefixIds {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if !self.prefix_ids && !self.prefix_class_names {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if !self.prefix_ids && !self.prefix_class_names {
             PrepareOutcome::skip
         } else {
             PrepareOutcome::none
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
@@ -20,7 +20,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveAttributesBySelect
     type Error = String;
 
     fn document(
-        &mut self,
+        &self,
         document: &mut E,
         _context: &Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_comments.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_comments.rs
@@ -16,7 +16,7 @@ pub struct PreservePattern(pub regex::Regex);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveComments {
     type Error = String;
 
-    fn comment(&mut self, comment: &mut <E as Node<'arena>>::Child) -> Result<(), Self::Error> {
+    fn comment(&self, comment: &mut <E as Node<'arena>>::Child) -> Result<(), Self::Error> {
         self.remove_comment(comment);
         Ok(())
     }

--- a/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
@@ -4,7 +4,7 @@ use lightningcss::{stylesheet::StyleSheet, values::ident::Ident, visit_types};
 use oxvg_ast::{
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::{
     allowed_content::{attrs_group_deprecated_unsafe, ELEMS},
@@ -90,12 +90,17 @@ impl Default for RemoveDeprecatedAttrs {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveDeprecatedAttrs {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        PrepareOutcome::use_style
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(PrepareOutcome::use_style)
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_desc.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_desc.rs
@@ -15,7 +15,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveDesc {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
@@ -1,6 +1,6 @@
 use oxvg_ast::{
     element::Element,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -11,16 +11,21 @@ pub struct RemoveDimensions(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveDimensions {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
@@ -1,7 +1,7 @@
 use oxvg_ast::{
     element::Element,
     node::Node,
-    visitor::{ContextFlags, PrepareOutcome, Visitor},
+    visitor::{ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -12,15 +12,20 @@ pub struct RemoveDoctype(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveDoctype {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
-    fn doctype(&mut self, doctype: &mut <E as Node<'arena>>::Child) -> Result<(), Self::Error> {
+    fn doctype(&self, doctype: &mut <E as Node<'arena>>::Child) -> Result<(), Self::Error> {
         doctype.remove();
         Ok(())
     }

--- a/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
@@ -27,7 +27,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveElementsByAttr {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
@@ -2,7 +2,7 @@ use oxvg_ast::{
     attribute::{Attr, Attributes},
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::CONDITIONAL_PROCESSING;
 use serde::{Deserialize, Serialize};
@@ -15,19 +15,20 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveEmptyAttrs {
     type Error = String;
 
     fn prepare(
-        &mut self,
+        &self,
         _document: &E,
+        _info: &Info<'arena, E>,
         _context_flags: &mut ContextFlags,
-    ) -> super::PrepareOutcome {
-        if self.0 {
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
@@ -5,7 +5,7 @@ use oxvg_ast::{
     get_computed_styles_factory,
     name::Name,
     style::{Id, PresentationAttrId},
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::CONTAINER;
 use serde::{Deserialize, Serialize};
@@ -18,23 +18,24 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveEmptyContainers {
     type Error = String;
 
     fn prepare(
-        &mut self,
+        &self,
         _document: &E,
+        _info: &Info<'arena, E>,
         _context_flags: &mut ContextFlags,
-    ) -> super::PrepareOutcome {
-        if self.0 {
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::use_style
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
-    fn use_style(&mut self, element: &E) -> bool {
+    fn use_style(&self, element: &E) -> bool {
         element.prefix().is_none() && element.local_name().as_ref() == "g"
     }
 
     fn exit_element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
@@ -18,7 +18,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveEmptyText {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     collections::{HashMap, HashSet},
     marker::PhantomData,
 };
@@ -17,7 +18,7 @@ use oxvg_ast::{
     get_computed_styles_factory,
     name::Name,
     style::{Id, PresentationAttr, PresentationAttrId, Static},
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::NON_RENDERING;
 use oxvg_path::Path;
@@ -49,11 +50,11 @@ pub struct RemoveHiddenElems {
 #[derive_where(Default, Debug)]
 struct Data<'arena, E: Element<'arena>> {
     opacity_zero: bool,
-    non_rendered_nodes: HashSet<E>,
-    removed_def_ids: HashSet<String>,
-    all_defs: HashSet<E>,
-    all_references: HashSet<String>,
-    references_by_id: HashMap<String, Vec<(E, E)>>,
+    non_rendered_nodes: RefCell<HashSet<E>>,
+    removed_def_ids: RefCell<HashSet<String>>,
+    all_defs: RefCell<HashSet<E>>,
+    all_references: RefCell<HashSet<String>>,
+    references_by_id: RefCell<HashMap<String, Vec<(E, E)>>>,
     marker: PhantomData<&'arena ()>,
 }
 
@@ -65,24 +66,29 @@ struct State<'o, 'arena, E: Element<'arena>> {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for Data<'arena, E> {
     type Error = String;
 
-    fn prepare(&mut self, document: &E, context_flags: &mut ContextFlags) -> super::PrepareOutcome {
+    fn prepare(
+        &self,
+        document: &E,
+        _info: &Info<'arena, E>,
+        context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
         context_flags.query_has_script(document);
         context_flags.query_has_stylesheet(document);
-        PrepareOutcome::use_style
+        Ok(PrepareOutcome::use_style)
     }
 
-    fn use_style(&mut self, element: &E) -> bool {
+    fn use_style(&self, element: &E) -> bool {
         let name = element.qual_name().formatter().to_string();
         !NON_RENDERING.contains(&name)
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
         if !context.flags.contains(ContextFlags::use_style) {
-            self.non_rendered_nodes.insert(element.clone());
+            self.non_rendered_nodes.borrow_mut().insert(element.clone());
             context.flags.visit_skip();
             return Ok(());
         }
@@ -100,7 +106,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for Data<'arena, E> {
                 {
                     let name = element.qual_name();
                     if name.prefix().is_none() && name.local_name().as_ref() == "path" {
-                        self.non_rendered_nodes.insert(element.clone());
+                        self.non_rendered_nodes.borrow_mut().insert(element.clone());
                         context.flags.visit_skip();
                         return Ok(());
                     }
@@ -113,11 +119,11 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for Data<'arena, E> {
 }
 
 impl<'arena, E: Element<'arena>> Data<'arena, E> {
-    fn remove_element(&mut self, element: &E) {
+    fn remove_element(&self, element: &E) {
         if let Some(parent) = Element::parent_element(element) {
             if parent.prefix().is_none() && parent.local_name().as_ref() == "defs" {
                 if let Some(id) = element.get_attribute_local(&"id".into()) {
-                    self.removed_def_ids.insert(id.to_string());
+                    self.removed_def_ids.borrow_mut().insert(id.to_string());
                 }
                 if parent.child_element_count() == 1 {
                     log::debug!("data: removing parent");
@@ -134,42 +140,49 @@ impl<'arena, E: Element<'arena>> Data<'arena, E> {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveHiddenElems {
     type Error = String;
 
-    fn document(
-        &mut self,
-        document: &mut E,
-        context: &Context<'arena, '_, '_, E>,
-    ) -> Result<(), Self::Error> {
+    fn prepare(
+        &self,
+        document: &E,
+        info: &Info<'arena, E>,
+        context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
         log::debug!("collecting data");
+        context_flags.query_has_script(document);
+        context_flags.query_has_stylesheet(document);
+        let document = &mut document.clone();
         let mut data = Data {
             opacity_zero: self.opacity_zero.unwrap_or(true),
             ..Data::default()
         };
-        data.start(document, context.info)?;
+        data.start(document, info, Some(context_flags.clone()))?;
         log::debug!("data collected");
         State {
             options: &self,
             data: &mut data,
         }
-        .start(document, context.info)
-        .map(|_| ())
+        .start(document, info, Some(context_flags.clone()))?;
+        Ok(PrepareOutcome::skip)
     }
 }
 
 impl<'o, 'arena, E: Element<'arena>> Visitor<'arena, E> for State<'o, 'arena, E> {
     type Error = String;
 
-    fn prepare(&mut self, document: &E, context_flags: &mut ContextFlags) -> super::PrepareOutcome {
-        context_flags.query_has_script(document);
-        context_flags.query_has_stylesheet(document);
-        PrepareOutcome::use_style
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(PrepareOutcome::use_style)
     }
 
-    fn use_style(&mut self, _element: &E) -> bool {
+    fn use_style(&self, _element: &E) -> bool {
         true
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {
@@ -198,10 +211,11 @@ impl<'o, 'arena, E: Element<'arena>> Visitor<'arena, E> for State<'o, 'arena, E>
 
             let ids = find_references(local_name.as_ref(), value.as_ref());
             if let Some(ids) = ids {
+                let mut all_references = self.data.all_references.borrow_mut();
                 ids.filter_map(|id| id.get(1))
                     .map(|id| id.as_str().to_string())
                     .for_each(|id| {
-                        self.data.all_references.insert(id);
+                        all_references.insert(id);
                     });
             }
         }
@@ -209,12 +223,12 @@ impl<'o, 'arena, E: Element<'arena>> Visitor<'arena, E> for State<'o, 'arena, E>
     }
 
     fn exit_document(
-        &mut self,
+        &self,
         _document: &mut E,
         context: &Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
-        for id in &self.data.removed_def_ids {
-            if let Some(refs) = self.data.references_by_id.get(id) {
+        for id in &*self.data.removed_def_ids.borrow() {
+            if let Some(refs) = self.data.references_by_id.borrow().get(id) {
                 for (node, _parent_node) in refs {
                     log::debug!("RemoveHiddenElems: remove referenced by id");
                     node.remove();
@@ -226,7 +240,7 @@ impl<'o, 'arena, E: Element<'arena>> Visitor<'arena, E> for State<'o, 'arena, E>
             .flags
             .intersects(ContextFlags::has_stylesheet & ContextFlags::has_script_ref);
         if !deoptimized {
-            for non_rendered_node in &self.data.non_rendered_nodes {
+            for non_rendered_node in &*self.data.non_rendered_nodes.borrow() {
                 if self.can_remove_non_rendering_node(non_rendered_node) {
                     log::debug!("RemoveHiddenElems: remove non-rendered node");
                     non_rendered_node.remove();
@@ -234,7 +248,7 @@ impl<'o, 'arena, E: Element<'arena>> Visitor<'arena, E> for State<'o, 'arena, E>
             }
         }
 
-        for node in &self.data.all_defs {
+        for node in &*self.data.all_defs.borrow() {
             if node.is_empty() {
                 log::debug!("RemoveHiddenElems: remove def");
                 node.remove();
@@ -248,7 +262,7 @@ impl<'o, 'arena, E: Element<'arena>> Visitor<'arena, E> for State<'o, 'arena, E>
 impl<'o, 'arena, E: Element<'arena>> State<'o, 'arena, E> {
     fn can_remove_non_rendering_node(&self, element: &E) -> bool {
         if let Some(id) = element.get_attribute_local(&"id".into()) {
-            if self.data.all_references.contains(id.as_ref()) {
+            if self.data.all_references.borrow().contains(id.as_ref()) {
                 return false;
             }
         }
@@ -257,9 +271,9 @@ impl<'o, 'arena, E: Element<'arena>> State<'o, 'arena, E> {
             .all(|e| E::new(e).is_none_or(|e| self.can_remove_non_rendering_node(&e)))
     }
 
-    fn ref_element(&mut self, element: &E, parent: &E, name: &str) {
+    fn ref_element(&self, element: &E, parent: &E, name: &str) {
         if name == "defs" {
-            self.data.all_defs.insert(element.clone());
+            self.data.all_defs.borrow_mut().insert(element.clone());
         } else if name == "use" {
             for attr in element.attributes().into_iter() {
                 if attr.local_name().as_ref() != "href" {
@@ -268,12 +282,12 @@ impl<'o, 'arena, E: Element<'arena>> State<'o, 'arena, E> {
                 let value = attr.value();
                 let id = &value.as_ref()[1..];
 
-                let refs = self.data.references_by_id.get_mut(id);
+                let mut references_by_id = self.data.references_by_id.borrow_mut();
+                let refs = references_by_id.get_mut(id);
                 match refs {
                     Some(refs) => refs.push((element.clone(), parent.clone())),
                     None => {
-                        self.data
-                            .references_by_id
+                        references_by_id
                             .insert(id.to_string(), vec![(element.clone(), parent.clone())]);
                     }
                 }

--- a/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
@@ -1,7 +1,7 @@
 use oxvg_ast::{
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -13,19 +13,20 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveMetadata {
     type Error = String;
 
     fn prepare(
-        &mut self,
+        &self,
         _document: &E,
+        _info: &Info<'arena, E>,
         _context_flags: &mut ContextFlags,
-    ) -> super::PrepareOutcome {
-        if self.0 {
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
@@ -3,7 +3,7 @@ use oxvg_ast::{
     element::Element,
     name::Name,
     style::PresentationAttrId,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::{AttrsGroups, Group, PRESENTATION_NON_INHERITABLE_GROUP_ATTRS};
 use serde::{Deserialize, Serialize};
@@ -15,16 +15,21 @@ pub struct RemoveNonInheritableGroupAttrs(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveNonInheritableGroupAttrs {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
@@ -1,7 +1,7 @@
 use oxvg_ast::{
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -12,16 +12,21 @@ pub struct RemoveRasterImages(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveRasterImages {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
@@ -3,8 +3,7 @@ use oxvg_ast::{
     element::Element,
     name::Name,
     node::{self, Node},
-    serialize::Node as _,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::EVENT_ATTRS;
 use serde::{Deserialize, Serialize};
@@ -15,16 +14,21 @@ pub struct RemoveScripts(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveScripts {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {
@@ -42,7 +46,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveScripts {
     }
 
     fn exit_element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
@@ -1,6 +1,6 @@
 use oxvg_ast::{
     element::Element,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -10,16 +10,21 @@ pub struct RemoveStyleElement(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveStyleElement {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_title.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_title.rs
@@ -1,6 +1,6 @@
 use oxvg_ast::{
     element::Element,
-    visitor::{Context, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -11,19 +11,20 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveTitle {
     type Error = String;
 
     fn prepare(
-        &mut self,
+        &self,
         _document: &E,
-        _context_flags: &mut oxvg_ast::visitor::ContextFlags,
-    ) -> oxvg_ast::visitor::PrepareOutcome {
-        if self.0 {
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
@@ -4,7 +4,7 @@ use oxvg_ast::{
     attribute::{Attr, Attributes},
     node,
     style::{Id, PresentationAttr, PresentationAttrId, Style},
-    visitor::{Context, ContextFlags, PrepareOutcome},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome},
 };
 use std::collections::{HashMap, HashSet};
 
@@ -55,16 +55,21 @@ impl Default for RemoveUnknownsAndDefaults {
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveUnknownsAndDefaults {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        PrepareOutcome::use_style
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(PrepareOutcome::use_style)
     }
 
-    fn use_style(&mut self, element: &E) -> bool {
+    fn use_style(&self, element: &E) -> bool {
         element.attributes().len() > 0
     }
 
     fn processing_instruction(
-        &mut self,
+        &self,
         processing_instruction: &mut <E as oxvg_ast::node::Node<'arena>>::Child,
         context: &Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
@@ -88,7 +93,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveUnknownsAndDefault
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
@@ -1,11 +1,11 @@
-use std::collections::HashSet;
+use std::{cell::RefCell, collections::HashSet};
 
 use derive_where::derive_where;
 use oxvg_ast::{
     attribute::{Attr, Attributes},
     element::Element,
     name::Name,
-    visitor::{Context, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,32 +16,22 @@ pub struct RemoveUnusedNS {
 
 #[derive_where(Default)]
 struct State<'arena, E: Element<'arena>> {
-    unused_namespaces: HashSet<<E::Name as Name>::LocalName>,
+    unused_namespaces: RefCell<HashSet<<E::Name as Name>::LocalName>>,
 }
 
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveUnusedNS {
     type Error = String;
 
     fn prepare(
-        &mut self,
-        _document: &E,
-        _context_flags: &mut oxvg_ast::visitor::ContextFlags,
-    ) -> oxvg_ast::visitor::PrepareOutcome {
+        &self,
+        document: &E,
+        info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
         if self.enabled {
-            PrepareOutcome::none
-        } else {
-            PrepareOutcome::skip
+            State::<'arena, E>::default().start(&mut document.clone(), info, None)?;
         }
-    }
-
-    fn document(
-        &mut self,
-        document: &mut E,
-        context: &Context<'arena, '_, '_, E>,
-    ) -> Result<(), Self::Error> {
-        State::<'arena, E>::default()
-            .start(document, context.info)
-            .map(|_| ())
+        Ok(PrepareOutcome::skip)
     }
 }
 
@@ -49,7 +39,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'arena, E> {
     type Error = String;
 
     fn document(
-        &mut self,
+        &self,
         document: &mut E,
         _content: &Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
@@ -60,20 +50,21 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'arena, E> {
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
-        context: &mut Context<'arena, '_, '_, E>,
+        _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
-        if self.unused_namespaces.is_empty() {
+        let mut unused_namespaces = self.unused_namespaces.borrow_mut();
+        if unused_namespaces.is_empty() {
             return Ok(());
         }
         if let Some(prefix) = element.prefix() {
-            self.unused_namespaces.remove(&prefix.as_ref().into());
+            unused_namespaces.remove(&prefix.as_ref().into());
         }
 
         for attr in element.attributes().into_iter() {
             if let Some(prefix) = attr.prefix() {
-                self.unused_namespaces.remove(&prefix.as_ref().into());
+                unused_namespaces.remove(&prefix.as_ref().into());
             }
         }
 
@@ -81,7 +72,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'arena, E> {
     }
 
     fn exit_document(
-        &mut self,
+        &self,
         document: &mut E,
         _context: &Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
@@ -93,15 +84,16 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'arena, E> {
 }
 
 impl<'arena, E: Element<'arena>> State<'arena, E> {
-    fn root_element(&mut self, element: &E) {
+    fn root_element(&self, element: &E) {
         if element.prefix().is_none() && element.local_name().as_ref() == "svg" {
+            let mut unused_namespaces = self.unused_namespaces.borrow_mut();
             for attr in element.attributes().into_iter() {
                 if attr
                     .prefix()
                     .as_ref()
                     .is_some_and(|p| p.as_ref() == "xmlns")
                 {
-                    self.unused_namespaces.insert(attr.local_name().clone());
+                    unused_namespaces.insert(attr.local_name().clone());
                 }
             }
         }
@@ -112,7 +104,7 @@ impl<'arena, E: Element<'arena>> State<'arena, E> {
             return;
         }
 
-        for name in &self.unused_namespaces {
+        for name in &*self.unused_namespaces.borrow() {
             log::debug!("removing xmlns:{name}");
             let name = E::Name::new(Some("xmlns".into()), name.clone());
             element.remove_attribute(&name);

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
@@ -2,7 +2,7 @@ use oxvg_ast::{
     atom::Atom,
     element::Element,
     name::Name,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::{ElementGroup, Group};
 use serde::{Deserialize, Serialize};
@@ -15,19 +15,20 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveUselessDefs {
     type Error = String;
 
     fn prepare(
-        &mut self,
+        &self,
         _document: &E,
+        _info: &Info<'arena, E>,
         _context_flags: &mut ContextFlags,
-    ) -> super::PrepareOutcome {
-        if self.0 {
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use lightningcss::{
     properties::{svg::SVGPaint, Property, PropertyId},
     traits::Zero,
@@ -9,7 +11,7 @@ use oxvg_ast::{
     get_computed_styles_factory,
     name::Name,
     style::{Id, PresentationAttr, PresentationAttrId, Static},
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::collections::{ElementGroup, Group};
 use serde::{Deserialize, Serialize};
@@ -23,42 +25,60 @@ pub struct RemoveUselessStrokeAndFill {
     pub fill: bool,
     #[serde(default = "default_remove_none")]
     pub remove_none: bool,
-    #[serde(skip_deserializing, skip_serializing)]
-    pub id_rc_byte: Option<usize>,
 }
 
-impl Default for RemoveUselessStrokeAndFill {
-    fn default() -> Self {
-        RemoveUselessStrokeAndFill {
-            stroke: default_stroke(),
-            fill: default_fill(),
-            remove_none: default_remove_none(),
-            id_rc_byte: None,
-        }
-    }
+struct State<'o> {
+    options: &'o RemoveUselessStrokeAndFill,
+    id_rc_byte: Cell<Option<usize>>,
 }
 
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveUselessStrokeAndFill {
     type Error = String;
 
-    fn prepare(&mut self, document: &E, context_flags: &mut ContextFlags) -> PrepareOutcome {
+    fn prepare(
+        &self,
+        document: &E,
+        info: &Info<'arena, E>,
+        context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
         context_flags.query_has_script(document);
         context_flags.query_has_stylesheet(document);
-        if context_flags.intersects(ContextFlags::has_stylesheet | ContextFlags::has_script_ref) {
-            PrepareOutcome::skip
-        } else {
-            PrepareOutcome::use_style
+        State {
+            options: self,
+            id_rc_byte: Cell::new(None),
         }
+        .start(&mut document.clone(), info, Some(context_flags.clone()))?;
+        Ok(PrepareOutcome::skip)
+    }
+}
+
+impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'_> {
+    type Error = String;
+
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(
+            if context_flags.intersects(ContextFlags::has_stylesheet | ContextFlags::has_script_ref)
+            {
+                PrepareOutcome::skip
+            } else {
+                PrepareOutcome::use_style
+            },
+        )
     }
 
-    fn use_style(&mut self, element: &E) -> bool {
-        if self.id_rc_byte.is_some() {
+    fn use_style(&self, element: &E) -> bool {
+        if self.id_rc_byte.get().is_some() {
             return false;
         }
 
         if element.has_attribute_local(&"id".into()) {
             log::debug!("flagged as id root");
-            self.id_rc_byte = Some(element.id());
+            self.id_rc_byte.set(Some(element.id()));
             return false;
         }
 
@@ -70,7 +90,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveUselessStrokeAndFi
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
@@ -85,26 +105,26 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveUselessStrokeAndFi
     }
 
     fn exit_element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
-        if self.id_rc_byte.is_some_and(|b| b == element.id()) {
+        if self.id_rc_byte.get().is_some_and(|b| b == element.id()) {
             log::debug!("unflagged as id root");
-            self.id_rc_byte = None;
+            self.id_rc_byte.set(None);
         }
 
         Ok(())
     }
 }
 
-impl RemoveUselessStrokeAndFill {
+impl State<'_> {
     fn remove_stroke<'arena, E: Element<'arena>>(
         &self,
         element: &E,
         context: &mut Context<'arena, '_, '_, E>,
     ) {
-        if !self.stroke {
+        if !self.options.stroke {
             return;
         }
 
@@ -198,7 +218,7 @@ impl RemoveUselessStrokeAndFill {
             }
         }
 
-        if is_stroke_eq_none && self.remove_none {
+        if is_stroke_eq_none && self.options.remove_none {
             log::debug!("removing element with no stroke");
             element.remove();
         }
@@ -209,7 +229,7 @@ impl RemoveUselessStrokeAndFill {
         element: &E,
         context: &mut Context<'arena, '_, '_, E>,
     ) {
-        if !self.fill {
+        if !self.options.fill {
             return;
         }
 
@@ -250,9 +270,19 @@ impl RemoveUselessStrokeAndFill {
             }
         }
 
-        if is_fill_eq_none && self.remove_none {
+        if is_fill_eq_none && self.options.remove_none {
             log::debug!("removing element with no fill");
             element.remove();
+        }
+    }
+}
+
+impl Default for RemoveUselessStrokeAndFill {
+    fn default() -> Self {
+        RemoveUselessStrokeAndFill {
+            stroke: default_stroke(),
+            fill: default_fill(),
+            remove_none: default_remove_none(),
         }
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
@@ -2,7 +2,7 @@ use oxvg_ast::{
     element::Element,
     name::Name,
     node::{self, Node},
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -14,19 +14,20 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveViewBox {
     type Error = String;
 
     fn prepare(
-        &mut self,
+        &self,
         _document: &E,
+        _info: &Info<'arena, E>,
         _context_flags: &mut ContextFlags,
-    ) -> super::PrepareOutcome {
-        if self.0 {
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/remove_x_m_l_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_x_m_l_n_s.rs
@@ -1,6 +1,6 @@
 use oxvg_ast::{
     element::Element,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -10,16 +10,21 @@ pub struct RemoveXMLNS(bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveXMLNS {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{cell::RefCell, marker::PhantomData};
 
 use oxvg_ast::{
     attribute::{Attr, Attributes},
@@ -6,7 +6,7 @@ use oxvg_ast::{
     element::Element,
     name::Name,
     node::Node,
-    visitor::{Context, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::allowed_content::ELEMS;
 use phf::{phf_map, phf_set};
@@ -20,29 +20,30 @@ pub struct RemoveXlink {
 
 struct State<'o, 'arena, E: Element<'arena>> {
     options: &'o RemoveXlink,
-    xlink_prefixes: Vec<<E::Name as Name>::Prefix>,
-    overridden_prefixes: Vec<<E::Name as Name>::Prefix>,
-    used_in_legacy_element: Vec<<E::Name as Name>::Prefix>,
+    xlink_prefixes: RefCell<Vec<<E::Name as Name>::Prefix>>,
+    overridden_prefixes: RefCell<Vec<<E::Name as Name>::Prefix>>,
+    used_in_legacy_element: RefCell<Vec<<E::Name as Name>::Prefix>>,
     marker: PhantomData<&'arena ()>,
 }
 
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveXlink {
     type Error = String;
 
-    fn document(
-        &mut self,
-        document: &mut E,
-        context: &Context<'arena, '_, '_, E>,
-    ) -> Result<(), Self::Error> {
+    fn prepare(
+        &self,
+        document: &E,
+        info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
         State {
             options: &*self,
-            xlink_prefixes: vec![],
-            overridden_prefixes: vec![],
-            used_in_legacy_element: vec![],
+            xlink_prefixes: RefCell::new(vec![]),
+            overridden_prefixes: RefCell::new(vec![]),
+            used_in_legacy_element: RefCell::new(vec![]),
             marker: PhantomData,
         }
-        .start(document, context.info)
-        .map(|_| ())
+        .start(&mut document.clone(), info, None)?;
+        Ok(PrepareOutcome::skip)
     }
 }
 
@@ -50,10 +51,12 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'_, 'arena, E> {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {
+        let mut xlink_prefixes = self.xlink_prefixes.borrow_mut();
+        let mut overridden_prefixes = self.overridden_prefixes.borrow_mut();
         for attr in element.attributes().into_iter() {
             if let Some(prefix) = attr.prefix() {
                 if prefix.as_ref() != "xmlns" {
@@ -62,20 +65,21 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'_, 'arena, E> {
 
                 let prefix_name = attr.local_name().as_ref().into();
                 if attr.value().as_ref() == XLINK_NAMESPACE {
-                    self.xlink_prefixes.push(prefix_name);
-                } else if self.xlink_prefixes.contains(&prefix_name) {
-                    self.overridden_prefixes.push(prefix_name);
+                    xlink_prefixes.push(prefix_name);
+                } else if xlink_prefixes.contains(&prefix_name) {
+                    overridden_prefixes.push(prefix_name);
                 }
             }
         }
 
-        if self
-            .overridden_prefixes
+        if overridden_prefixes
             .iter()
-            .any(|p| self.xlink_prefixes.contains(p))
+            .any(|p| xlink_prefixes.contains(p))
         {
             return Ok(());
         }
+        drop(xlink_prefixes);
+        drop(overridden_prefixes);
 
         self.handle_show(element);
         self.handle_title(element, context);
@@ -85,7 +89,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'_, 'arena, E> {
     }
 
     fn exit_element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {
@@ -94,24 +98,27 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'_, 'arena, E> {
                 return true;
             };
 
+            let mut xlink_prefixes = self.xlink_prefixes.borrow_mut();
+            let mut overridden_prefixes = self.overridden_prefixes.borrow_mut();
+            let used_in_legacy_element = self.used_in_legacy_element.borrow();
             if !self.options.include_legacy
-                && self.xlink_prefixes.contains(prefix)
-                && !self.overridden_prefixes.contains(prefix)
-                && !self.used_in_legacy_element.contains(prefix)
+                && xlink_prefixes.contains(prefix)
+                && !overridden_prefixes.contains(prefix)
+                && !used_in_legacy_element.contains(prefix)
             {
                 return false;
             }
 
             let value = attr.value();
             if prefix.as_ref() == "xmlns"
-                && !self.used_in_legacy_element.contains(&value.as_ref().into())
+                && !used_in_legacy_element.contains(&value.as_ref().into())
             {
                 if value.as_ref() == XLINK_NAMESPACE {
-                    self.xlink_prefixes.retain(|p| p.as_ref() != value.as_ref());
+                    xlink_prefixes.retain(|p| p.as_ref() != value.as_ref());
                     return false;
                 }
 
-                self.overridden_prefixes.retain(|p| p != prefix);
+                overridden_prefixes.retain(|p| p != prefix);
             }
 
             true
@@ -123,6 +130,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for State<'_, 'arena, E> {
 
 impl<'arena, E: Element<'arena>> State<'_, 'arena, E> {
     fn handle_show(&self, element: &E) {
+        let xlink_prefixes = self.xlink_prefixes.borrow();
         let element_name = element.qual_name().formatter().to_string();
         let target_name = "target".into();
         let mut show_handled = element.has_attribute_local(&target_name);
@@ -131,7 +139,7 @@ impl<'arena, E: Element<'arena>> State<'_, 'arena, E> {
             let Some(prefix) = attr.prefix() else {
                 return true;
             };
-            if attr.local_name().as_ref() != "show" || !self.xlink_prefixes.contains(prefix) {
+            if attr.local_name().as_ref() != "show" || !xlink_prefixes.contains(prefix) {
                 return true;
             }
             if show_handled {
@@ -158,11 +166,12 @@ impl<'arena, E: Element<'arena>> State<'_, 'arena, E> {
     }
 
     fn handle_title(&self, element: &E, context: &Context<'arena, '_, '_, E>) {
+        let xlink_prefixes = self.xlink_prefixes.borrow();
         element.attributes().retain(|attr| {
             let Some(prefix) = attr.prefix() else {
                 return true;
             };
-            if attr.local_name().as_ref() != "title" || !self.xlink_prefixes.contains(prefix) {
+            if attr.local_name().as_ref() != "title" || !xlink_prefixes.contains(prefix) {
                 return true;
             }
 
@@ -185,7 +194,9 @@ impl<'arena, E: Element<'arena>> State<'_, 'arena, E> {
         });
     }
 
-    fn handle_href(&mut self, element: &E) {
+    fn handle_href(&self, element: &E) {
+        let mut used_in_legacy_element = self.used_in_legacy_element.borrow_mut();
+        let xlink_prefixes = self.xlink_prefixes.borrow();
         let exclude_legacy = !self.options.include_legacy
             && element.prefix().is_none()
             && LEGACY_ELEMENTS.contains(element.local_name());
@@ -196,12 +207,12 @@ impl<'arena, E: Element<'arena>> State<'_, 'arena, E> {
                 has_href = has_href || attr.value().as_ref() == "href";
                 return true;
             };
-            if attr.local_name().as_ref() != "href" || !self.xlink_prefixes.contains(prefix) {
+            if attr.local_name().as_ref() != "href" || !xlink_prefixes.contains(prefix) {
                 log::debug!("retaining {:?}, not a recorded prefix", attr);
                 return true;
             }
             if exclude_legacy {
-                self.used_in_legacy_element.push(prefix.clone());
+                used_in_legacy_element.push(prefix.clone());
                 return true;
             }
 

--- a/crates/oxvg_optimiser/src/jobs/remove_xml_proc_inst.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_xml_proc_inst.rs
@@ -1,7 +1,7 @@
 use oxvg_ast::{
     element::Element,
     node::Node,
-    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -12,16 +12,21 @@ pub struct RemoveXMLProcInst(pub bool);
 impl<'arena, E: Element<'arena>> Visitor<'arena, E> for RemoveXMLProcInst {
     type Error = String;
 
-    fn prepare(&mut self, _document: &E, _context_flags: &mut ContextFlags) -> PrepareOutcome {
-        if self.0 {
+    fn prepare(
+        &self,
+        _document: &E,
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn processing_instruction(
-        &mut self,
+        &self,
         processing_instruction: &mut <E as Node<'arena>>::Child,
         _context: &Context<'arena, '_, '_, E>,
     ) -> Result<(), Self::Error> {

--- a/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
@@ -24,7 +24,7 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for SortAttrs {
     type Error = String;
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {

--- a/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, collections::HashMap};
 use oxvg_ast::{
     element::Element,
     name::Name,
-    visitor::{Context, PrepareOutcome, Visitor},
+    visitor::{Context, ContextFlags, Info, PrepareOutcome, Visitor},
 };
 use serde::{Deserialize, Serialize};
 
@@ -14,19 +14,20 @@ impl<'arena, E: Element<'arena>> Visitor<'arena, E> for SortDefsChildren {
     type Error = String;
 
     fn prepare(
-        &mut self,
+        &self,
         _document: &E,
-        _context_flags: &mut oxvg_ast::visitor::ContextFlags,
-    ) -> oxvg_ast::visitor::PrepareOutcome {
-        if self.0 {
+        _info: &Info<'arena, E>,
+        _context_flags: &mut ContextFlags,
+    ) -> Result<PrepareOutcome, Self::Error> {
+        Ok(if self.0 {
             PrepareOutcome::none
         } else {
             PrepareOutcome::skip
-        }
+        })
     }
 
     fn element(
-        &mut self,
+        &self,
         element: &mut E,
         _context: &mut Context<'arena, '_, '_, E>,
     ) -> Result<(), String> {


### PR DESCRIPTION
Some jobs stored state in their config, which risks accidentally mutating and reusing state across files. This PR updates visitors so that they're not used mutably.
Where state is needed, a short-lived visitor is created which uses the parent visitor as it's options.

This also means we no longer need to clone visitors as we iterate across files.