### PR TITLE
Fix arc parsing

### DIFF
--- a/crates/oxvg_path/src/lib.rs
+++ b/crates/oxvg_path/src/lib.rs
@@ -208,4 +208,7 @@ fn test_path_parse() {
 
     // Should error when args are missing
     assert!(Path::parse("m1").is_err());
+
+    // Parse arc with decimals as separators
+    insta::assert_snapshot!(Path::parse("m-0,1a20.8 20.8 0 0 0 5.2.6").unwrap());
 }

--- a/crates/oxvg_path/src/lib.rs
+++ b/crates/oxvg_path/src/lib.rs
@@ -211,4 +211,9 @@ fn test_path_parse() {
 
     // Parse arc with decimals as separators
     insta::assert_snapshot!(Path::parse("m-0,1a20.8 20.8 0 0 0 5.2.6").unwrap());
+
+    // Parse implicit arc
+    insta::assert_snapshot!(
+        Path::parse("m-0,1a29.6 29.6 0 01-2 1.5 151.6 151.6 0 01-2.6 1.8").unwrap()
+    );
 }

--- a/crates/oxvg_path/src/parser.rs
+++ b/crates/oxvg_path/src/parser.rs
@@ -170,7 +170,7 @@ impl Parser {
             }
             // read next argument
             if matches!(
-                self.current_command,
+                self.current_command.as_explicit(),
                 command::ID::ArcTo | command::ID::ArcBy
             ) {
                 let number = match char {

--- a/crates/oxvg_path/src/parser.rs
+++ b/crates/oxvg_path/src/parser.rs
@@ -181,6 +181,7 @@ impl Parser {
                     '0' if (3..=4).contains(&self.args_len) => 0.0,
                     '1' if (3..=4).contains(&self.args_len) => 1.0,
                     '+' | '-' | '.' | 'e' => {
+                        self.had_decminal = self.had_decminal || char == '.';
                         self.current_number.push(char);
                         continue;
                     }

--- a/crates/oxvg_path/src/snapshots/oxvg_path__path_parse-6.snap
+++ b/crates/oxvg_path/src/snapshots/oxvg_path__path_parse-6.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_path/src/lib.rs
+expression: "Path::parse(\"m-0,1a20.8 20.8 0 0 0 5.2.6\").unwrap()"
+---
+m0 1a20.8 20.8 0 0 0 5.2.6

--- a/crates/oxvg_path/src/snapshots/oxvg_path__path_parse-7.snap
+++ b/crates/oxvg_path/src/snapshots/oxvg_path__path_parse-7.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_path/src/lib.rs
+expression: "Path::parse(\"m-0,1a29.6 29.6 0 01-2 1.5 151.6 151.6 0 01-2.6 1.8\").unwrap()"
+---
+m0 1a29.6 29.6 0 0 1-2 1.5 151.6 151.6 0 0 1-2.6 1.8


### PR DESCRIPTION
Two issues found while testing on the Parcel website (these icons: https://github.com/parcel-bundler/website/tree/v2/src/assets/lang-icons)

1. Arcs with decimals that don't have any whitespace between their components were not parsing correctly
2. Arcs with multiple implicit commands were not parsing correctly

These manifested themselves as the path being removed entirely, due to the "remove hidden elems" job, which assumes that any path that fails to parse is hidden.