### PR TITLE
fix(optimiser): #165 prevent destroying zero value when zero precision is given

### DIFF
--- a/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
@@ -123,5 +123,14 @@ fn cleanup_numeric_values() -> anyhow::Result<()> {
         )
     )?);
 
+    insta::assert_snapshot!(test_config(
+        r#"{ "cleanupNumericValues": { "floatPrecision": 0 } }"#,
+        Some(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1052.4 744.1">
+    <!-- Should round to zero decimal places -->
+</svg>"#
+        )
+    )?);
+
     Ok(())
 }

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_numeric_values__cleanup_numeric_values-4.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_numeric_values__cleanup_numeric_values-4.snap
@@ -1,0 +1,7 @@
+---
+source: crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
+expression: "test_config(r#\"{ \"cleanupNumericValues\": { \"floatPrecision\": 0 } }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 1052.4 744.1\">\n    <!-- Should round to zero decimal places -->\n</svg>\"#))?"
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1052 744">
+    <!-- Should round to zero decimal places -->
+</svg>

--- a/crates/oxvg_optimiser/src/utils/cleanup_values.rs
+++ b/crates/oxvg_optimiser/src/utils/cleanup_values.rs
@@ -62,10 +62,12 @@ pub trait CleanupValues {
 
             let mut number = format!("{number:.float_precision$}");
             if leading_zero {
-                number = number
-                    .trim_end_matches('0')
-                    .trim_end_matches('.')
-                    .to_string();
+                if float_precision > 0 {
+                    number = number
+                        .trim_end_matches('0')
+                        .trim_end_matches('.')
+                        .to_string();
+                }
                 if number.starts_with("0.") {
                     number.remove(0);
                 } else if number.starts_with("-0.") {


### PR DESCRIPTION
Closes #165 