### PR TITLE
fix: #183 fix text escaping for style element content in xmlwriter

### DIFF
--- a/crates/oxvg_ast/src/xmlwriter.rs
+++ b/crates/oxvg_ast/src/xmlwriter.rs
@@ -339,6 +339,7 @@ enum Escape {
     AttributeValue,
     Text,
     CData,
+    Style,
 }
 
 impl<W: Write> fmt::Write for FmtWriter<W> {
@@ -351,7 +352,7 @@ impl<W: Write> fmt::Write for FmtWriter<W> {
             Escape::Text => self.write_escaped(s, false),
             // We don't bother escaping double hyphen (--) in comment as it's
             // unlikely to ever happen, and even libxml2 does not do it.
-            Escape::Comment | Escape::CData => self.writer.write_all(s.as_bytes()),
+            Escape::Comment | Escape::CData | Escape::Style => self.writer.write_all(s.as_bytes()),
         };
         if error.is_err() {
             self.error_kind = Some(error.as_ref().unwrap_err().kind());
@@ -792,6 +793,7 @@ impl<'input, W: Write> XmlWriter<'input, W> {
             return Ok(());
         }
         self.before_write_text(false)?;
+        self.fmt_writer.escape = Some(Escape::Style);
         style
             .write_value(&mut Printer::new(
                 &mut self.fmt_writer,

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__merge_styles__merge_styles-2.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__merge_styles__merge_styles-2.snap
@@ -5,7 +5,7 @@ expression: "test_config(r#\"{ \"mergeStyles\": true }\"#,\nSome(r#\"<svg id=\"t
 <svg xmlns="http://www.w3.org/2000/svg" id="test" viewBox="0 0 100 100">
     <!-- Appends media query to style -->
     <style>
-        .st0{fill:red;padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em}@media screen and (width&lt;=200px){.st0{display:none}}
+        .st0{fill:red;padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em}@media screen and (width<=200px){.st0{display:none}}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3px;margin-top:1em;margin-right:1em;margin-bottom:1em;margin-left:1em"/>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__merge_styles__merge_styles-4.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__merge_styles__merge_styles-4.snap
@@ -5,7 +5,7 @@ expression: "test_config(r#\"{ \"mergeStyles\": true }\"#,\nSome(r#\"<svg id=\"t
 <svg xmlns="http://www.w3.org/2000/svg" id="test" viewBox="0 0 100 100">
     <!-- Should handle multiple media attributes -->
     <style>
-        @media print{.st0{fill:red;padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em}}.test{background:red}@media only screen and (width&gt;=600px){.wrapper{color:#00f}}
+        @media print{.st0{fill:red;padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em}}.test{background:red}@media only screen and (width>=600px){.wrapper{color:#00f}}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3px;margin-top:1em;margin-right:1em;margin-bottom:1em;margin-left:1em"/>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-2.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-2.snap
@@ -4,7 +4,7 @@ expression: "test_config(r#\"{ \"minifyStyles\": {} }\"#,\nSome(r#\"<svg id=\"te
 ---
 <svg xmlns="http://www.w3.org/2000/svg" id="test" viewBox="0 0 100 100">
     <style>
-        .st0{fill:red;padding:1em}@media screen and (width&lt;=200px){.st0{display:none}}
+        .st0{fill:red;padding:1em}@media screen and (width<=200px){.st0{display:none}}
     </style>
     <style/>
     <rect width="100" height="100" class="st0" style="stroke-width:3px;margin:1em"/>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-3.snap
@@ -4,7 +4,7 @@ expression: "test_config(r#\"{ \"minifyStyles\": {} }\"#,\nSome(r#\"<svg id=\"te
 ---
 <svg xmlns="http://www.w3.org/2000/svg" id="test" viewBox="0 0 100 100">
     <style>
-        .st0{fill:red;background-image:url("data:image/svg,&lt;svg width=\"16\" height=\"16\"/&gt;");padding:1em}@media screen and (width&lt;=200px){.st0{display:none}}
+        .st0{fill:red;background-image:url("data:image/svg,<svg width=\"16\" height=\"16\"/>");padding:1em}@media screen and (width<=200px){.st0{display:none}}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3px;margin:1em"/>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles.snap
@@ -4,7 +4,7 @@ expression: "test_config(r#\"{ \"minifyStyles\": {} }\"#,\nSome(r#\"<svg id=\"te
 ---
 <svg xmlns="http://www.w3.org/2000/svg" id="test" viewBox="0 0 100 100">
     <style>
-        .st0{fill:red;padding:1em}@media screen and (width&lt;=200px){.st0{display:none}}
+        .st0{fill:red;padding:1em}@media screen and (width<=200px){.st0{display:none}}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3px;margin:1em"/>
 </svg>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

This PR updates serialization of the text-content of `<style>` elements, which should match the [HTML spec](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-style-element.html).

## Motivation and Context

- Escaping style content can cause the content to become invalid CSS

## How Has This Been Tested?

- Unit tests

## Types of changes
### Fixes

- Updated xmlwriter to print style content as unescaped character data

## Checklist:
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
