### PR TITLE
feat!: #189 improve whitespace handling

### DIFF
--- a/crates/oxvg/src/optimise.rs
+++ b/crates/oxvg/src/optimise.rs
@@ -66,13 +66,7 @@ impl RunCommand for Optimise {
 
 impl Optimise {
     fn handle_out<W: Write>(dom: Ref, wr: W) -> anyhow::Result<W> {
-        Ok(dom.serialize_into(
-            wr,
-            Options {
-                indent: Indent::None,
-                ..Options::default()
-            },
-        )?)
+        Ok(dom.serialize_into(wr, Options::default())?)
     }
 
     fn handle_stdin(&self, jobs: &Jobs) -> anyhow::Result<()> {

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -320,7 +320,11 @@ macro_rules! test_config {
 #[cfg(test)]
 pub(crate) fn test_config(config_json: &str, svg: Option<&'static str>) -> anyhow::Result<String> {
     use oxvg_ast::{
-        arena::Allocator, parse::roxmltree::parse, serialize::Node as _, serialize::Options,
+        arena::Allocator,
+        parse::roxmltree::parse,
+        serialize::Node as _,
+        serialize::Options,
+        xmlwriter::{Indent, Space},
     };
     use roxmltree;
 
@@ -343,7 +347,11 @@ pub(crate) fn test_config(config_json: &str, svg: Option<&'static str>) -> anyho
     let dom = parse(&xml, &mut allocator).unwrap();
     jobs.run(dom, &Info::new(allocator))
         .map_err(|e| anyhow::Error::msg(format!("{e}")))?;
-    Ok(dom.serialize_with_options(Options::default())?)
+    Ok(dom.serialize_with_options(Options {
+        trim_whitespace: Space::Default,
+        minify: true,
+        ..Options::pretty()
+    })?)
 }
 
 #[test]

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_ids__cleanup_ids.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_ids__cleanup_ids.snap
@@ -9,9 +9,7 @@ expression: "test_config(r#\"{ \"cleanupIds\": {} }\"#,\nSome(r##\"<svg xmlns=\"
             <stop offset="5%" stop-color="#f60"/>
             <stop offset="95%" stop-color="#ff6"/>
         </linearGradient>
-        <text id="b">
-            referenced text
-        </text>
+        <text id="b">referenced text</text>
         <path id="c" d="..."/>
         <path id="d" d="..."/>
         <path id="e" d="..."/>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_ids__cleanup_ids_check_rename.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_ids__cleanup_ids_check_rename.snap
@@ -4,165 +4,59 @@ expression: "test_config(r#\"{ \"cleanupIds\": {} }\"#,\nSome(r##\"<svg xmlns=\"
 ---
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs>
-        <text id="a">
-            referenced text
-        </text>
-        <text id="b">
-            referenced text
-        </text>
-        <text id="c">
-            referenced text
-        </text>
-        <text id="d">
-            referenced text
-        </text>
-        <text id="e">
-            referenced text
-        </text>
-        <text id="f">
-            referenced text
-        </text>
-        <text id="g">
-            referenced text
-        </text>
-        <text id="h">
-            referenced text
-        </text>
-        <text id="i">
-            referenced text
-        </text>
-        <text id="j">
-            referenced text
-        </text>
-        <text id="k">
-            referenced text
-        </text>
-        <text id="l">
-            referenced text
-        </text>
-        <text id="m">
-            referenced text
-        </text>
-        <text id="n">
-            referenced text
-        </text>
-        <text id="o">
-            referenced text
-        </text>
-        <text id="p">
-            referenced text
-        </text>
-        <text id="q">
-            referenced text
-        </text>
-        <text id="r">
-            referenced text
-        </text>
-        <text id="s">
-            referenced text
-        </text>
-        <text id="t">
-            referenced text
-        </text>
-        <text id="u">
-            referenced text
-        </text>
-        <text id="v">
-            referenced text
-        </text>
-        <text id="w">
-            referenced text
-        </text>
-        <text id="x">
-            referenced text
-        </text>
-        <text id="y">
-            referenced text
-        </text>
-        <text id="z">
-            referenced text
-        </text>
-        <text id="A">
-            referenced text
-        </text>
-        <text id="B">
-            referenced text
-        </text>
-        <text id="C">
-            referenced text
-        </text>
-        <text id="D">
-            referenced text
-        </text>
-        <text id="E">
-            referenced text
-        </text>
-        <text id="F">
-            referenced text
-        </text>
-        <text id="G">
-            referenced text
-        </text>
-        <text id="H">
-            referenced text
-        </text>
-        <text id="I">
-            referenced text
-        </text>
-        <text id="J">
-            referenced text
-        </text>
-        <text id="K">
-            referenced text
-        </text>
-        <text id="L">
-            referenced text
-        </text>
-        <text id="M">
-            referenced text
-        </text>
-        <text id="N">
-            referenced text
-        </text>
-        <text id="O">
-            referenced text
-        </text>
-        <text id="P">
-            referenced text
-        </text>
-        <text id="Q">
-            referenced text
-        </text>
-        <text id="R">
-            referenced text
-        </text>
-        <text id="S">
-            referenced text
-        </text>
-        <text id="T">
-            referenced text
-        </text>
-        <text id="U">
-            referenced text
-        </text>
-        <text id="V">
-            referenced text
-        </text>
-        <text id="W">
-            referenced text
-        </text>
-        <text id="X">
-            referenced text
-        </text>
-        <text id="Y">
-            referenced text
-        </text>
-        <text id="Z">
-            referenced text
-        </text>
-        <text id="aa">
-            referenced text
-        </text>
+        <text id="a">referenced text</text>
+        <text id="b">referenced text</text>
+        <text id="c">referenced text</text>
+        <text id="d">referenced text</text>
+        <text id="e">referenced text</text>
+        <text id="f">referenced text</text>
+        <text id="g">referenced text</text>
+        <text id="h">referenced text</text>
+        <text id="i">referenced text</text>
+        <text id="j">referenced text</text>
+        <text id="k">referenced text</text>
+        <text id="l">referenced text</text>
+        <text id="m">referenced text</text>
+        <text id="n">referenced text</text>
+        <text id="o">referenced text</text>
+        <text id="p">referenced text</text>
+        <text id="q">referenced text</text>
+        <text id="r">referenced text</text>
+        <text id="s">referenced text</text>
+        <text id="t">referenced text</text>
+        <text id="u">referenced text</text>
+        <text id="v">referenced text</text>
+        <text id="w">referenced text</text>
+        <text id="x">referenced text</text>
+        <text id="y">referenced text</text>
+        <text id="z">referenced text</text>
+        <text id="A">referenced text</text>
+        <text id="B">referenced text</text>
+        <text id="C">referenced text</text>
+        <text id="D">referenced text</text>
+        <text id="E">referenced text</text>
+        <text id="F">referenced text</text>
+        <text id="G">referenced text</text>
+        <text id="H">referenced text</text>
+        <text id="I">referenced text</text>
+        <text id="J">referenced text</text>
+        <text id="K">referenced text</text>
+        <text id="L">referenced text</text>
+        <text id="M">referenced text</text>
+        <text id="N">referenced text</text>
+        <text id="O">referenced text</text>
+        <text id="P">referenced text</text>
+        <text id="Q">referenced text</text>
+        <text id="R">referenced text</text>
+        <text id="S">referenced text</text>
+        <text id="T">referenced text</text>
+        <text id="U">referenced text</text>
+        <text id="V">referenced text</text>
+        <text id="W">referenced text</text>
+        <text id="X">referenced text</text>
+        <text id="Y">referenced text</text>
+        <text id="Z">referenced text</text>
+        <text id="aa">referenced text</text>
     </defs>
     <tref xlink:href="#a"/>
     <tref xlink:href="#a"/>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_list_of_values__cleanup_list_of_values-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__cleanup_list_of_values__cleanup_list_of_values-3.snap
@@ -4,7 +4,5 @@ expression: "test_config(r#\"{ \"cleanupListOfValues\": {} }\"#,\nSome(r#\"<svg 
 ---
 <svg xmlns="http://www.w3.org/2000/svg">
     <!-- Should cleanup x/y values -->
-    <text x="23.235 20.227 .224em 80.001%" y="23.235 20.227 .224em 80.001%" dx="23.235 20.227 .224em 80.001%" dy="23.235 20.227 .224em 80.001%">
-        test
-    </text>
+    <text x="23.235 20.227 .224em 80.001%" y="23.235 20.227 .224em 80.001%" dx="23.235 20.227 .224em 80.001%" dy="23.235 20.227 .224em 80.001%">test</text>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-9.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-9.snap
@@ -6,7 +6,5 @@ expression: "test_config(r#\"{ \"minifyStyles\": {} }\"#,\nSome(r#\"<svg viewBox
     <style type="text/css">
         .st6{stroke-opacity:0;fill-opacity:0;font-family:Helvetica LT Std,Helvetica,Arial;font-size:118px}
     </style>
-    <text class="st6" transform="translate(353.67 1514)">
-        tell stories in 250 characters
-    </text>
+    <text class="st6" transform="translate(353.67 1514)">tell stories in 250 characters</text>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_empty_containers__remove_empty_containers-6.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_empty_containers__remove_empty_containers-6.snap
@@ -6,8 +6,6 @@ expression: "test_config(r#\"{ \"removeEmptyContainers\": true }\"#,\nSome(r#\"<
     <!-- preserve children of `switch` -->
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
-        <a transform="translate(0 -5)" href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
-            <text text-anchor="middle" font-size="10px" x="50%" y="100%">Viewer does not support full SVG 1.1</text>
-        </a>
+        <a transform="translate(0 -5)" href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank"><text text-anchor="middle" font-size="10px" x="50%" y="100%">Viewer does not support full SVG 1.1</text></a>
     </switch>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_hidden_elems__remove_hidden_elems-19.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_hidden_elems__remove_hidden_elems-19.snap
@@ -7,9 +7,5 @@ expression: "test_config(r#\"{ \"removeHiddenElems\": {} }\"#,\nSome(r##\"<svg x
     <defs>
         <path id="path2" d="M200 200l50-300" style="opacity:0"/>
     </defs>
-    <text style="font-size:24px">
-        <textPath xlink:href="#path2">
-        this is path 2
-        </textPath>
-    </text>
+    <text style="font-size:24px"><textPath xlink:href="#path2">this is path 2</textPath></text>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_scripts__remove_scripts-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_scripts__remove_scripts-3.snap
@@ -3,7 +3,5 @@ source: crates/oxvg_optimiser/src/jobs/remove_scripts.rs
 expression: "test_config(r#\"{ \"removeScripts\": true }\"#,\nSome(r#\"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">\n  <a href=\"https://yewtu.be/watch?v=dQw4w9WgXcQ\">\n    <text y=\"10\" onclick=\"alert('uwu')\">uwu</text>\n  </a>\n</svg>\"#),)?"
 ---
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-    <a href="https://yewtu.be/watch?v=dQw4w9WgXcQ">
-    <text y="10">uwu</text>
-  </a>
+    <a href="https://yewtu.be/watch?v=dQw4w9WgXcQ"><text y="10">uwu</text></a>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unknowns_and_defaults__remove_unknowns_and_defaults-15.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_unknowns_and_defaults__remove_unknowns_and_defaults-15.snap
@@ -4,7 +4,5 @@ expression: "test_config(r#\"{ \"removeUnknownsAndDefaults\": {} }\"#,\nSome(r##
 ---
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="480" height="360">
     <!-- handle xlink and xmlns -->
-    <text x="50" y="50">
-        A <a xlink:href="#"/> for testing
-    </text>
+    <text x="50" y="50">A<a xlink:href="#"/>for testing</text>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_xlink__remove_xlink-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_xlink__remove_xlink-3.snap
@@ -4,8 +4,5 @@ expression: "test_config(r#\"{ \"removeXlink\": {} }\"#,\nSome(r#\"<svg xmlns=\"
 ---
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
     <!-- convert xlink:href, xlink:show, and xlink:title -->
-    <a target="_blank" href="https://duckduckgo.com"><title>
-            DuckDuckGo Homepage</title>
-    <text x="0" y="10">uwu</text>
-  </a>
+    <a target="_blank" href="https://duckduckgo.com"><title>DuckDuckGo Homepage</title><text x="0" y="10">uwu</text></a>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__reuse_paths__reuse_paths-3.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__reuse_paths__reuse_paths-3.snap
@@ -3,7 +3,5 @@ source: crates/oxvg_optimiser/src/jobs/reuse_paths.rs
 expression: "test_config(r#\"{ \"reusePaths\": true }\"#,\nSome(r#\"<svg viewBox=\"0 0 200 200\" xmlns=\"http://www.w3.org/2000/svg\">\n    <text>\n        text element\n    </text>\n</svg>\"#),)?"
 ---
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-    <text>
-        text element
-    </text>
+    <text>text element</text>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__sort_defs_children__sort_defs_children.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__sort_defs_children__sort_defs_children.snap
@@ -6,12 +6,8 @@ expression: "test_config(r#\"{ \"sortDefsChildren\": true }\"#,\nSome(r#\"<svg x
     <defs>
         <circle id="e" fill="none" fill-rule="evenodd" cx="60" cy="60" r="50"/>
         <circle id="f" fill="none" fill-rule="evenodd" cx="60" cy="60" r="50"/>
-        <text id="a">
-            referenced text
-        </text>
-        <text id="c">
-            referenced text
-        </text>
+        <text id="a">referenced text</text>
+        <text id="c">referenced text</text>
         <path id="b" d="M0 0ZM10 10ZM20 20l10 10M30 0c10 0 20 10 20 20M30 30Z"/>
         <path id="d" d="M30 30Z"/>
     </defs>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

This PR improves how whitespace is handled while writing SVG documents so that redundant whitespace is omitted.

## Motivation and Context

Previously whitespace would be conservatively retained, causing files to be larger than necessary.

## How Has This Been Tested?

- Unit tests
- w3c & oxygen

## Types of changes

### Features

- Removes redundant whitespace while printing SVG document
- Added handling for `xml:space="preserve"`

### Breaking changes

- Defaults of xmlwriter options updated to remove whitespace by default
- `TrimWhitespace` renamed to `Space`, updated variants

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [x] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
