### PR TITLE
perf: skip tokenisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "log",
  "napi",
  "napi-derive",
+ "oxvg_parse",
  "pretty_assertions",
  "ryu",
  "schemars 0.8.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,7 @@ version = "0.0.3"
 dependencies = [
  "bitflags",
  "insta",
+ "itertools 0.14.0",
  "log",
  "napi",
  "napi-derive",

--- a/crates/oxvg_collections/Cargo.toml
+++ b/crates/oxvg_collections/Cargo.toml
@@ -20,7 +20,7 @@ serialize = ["dep:oxvg_serialize"]
 markup5ever = ["dep:string_cache", "dep:tendril", "dep:xml5ever"]
 
 [dependencies]
-oxvg_parse = { workspace = true, optional = true }
+oxvg_parse = { workspace = true, features = ["lightningcss"], optional = true }
 oxvg_path = { workspace = true }
 oxvg_serialize = { workspace = true, optional = true }
 

--- a/crates/oxvg_collections/src/atom.rs
+++ b/crates/oxvg_collections/src/atom.rs
@@ -2,6 +2,7 @@
 use std::ops::Deref;
 
 use lightningcss::values::string::CowArcStr;
+use oxvg_parse::error::Error;
 #[cfg(feature = "markup5ever")]
 use tendril::SliceExt;
 
@@ -121,12 +122,12 @@ impl<'input> From<CowArcStr<'input>> for Atom<'input> {
 
 #[cfg(feature = "parse")]
 impl<'input> oxvg_parse::Parse<'input> for Atom<'input> {
-    fn parse<'t>(
-        input: &mut oxvg_parse::Parser<'input, 't>,
-    ) -> Result<Self, oxvg_parse::error::ParseError<'input>> {
-        let start = input.position();
-        while input.next().is_ok() {}
-        Ok(Self::Cow(input.slice_from(start).into()))
+    fn parse(input: &mut oxvg_parse::Parser<'input>) -> Result<Self, Error<'input>> {
+        Ok(input.take_slice().into())
+    }
+
+    fn parse_string(input: &'input str) -> Result<Self, Error<'input>> {
+        Ok(input.into())
     }
 }
 

--- a/crates/oxvg_collections/src/attribute.rs
+++ b/crates/oxvg_collections/src/attribute.rs
@@ -109,16 +109,15 @@ macro_rules! enum_attr {
         #[cfg(feature = "parse")]
         impl<'input> $crate::attribute::Parse<'input> for $attr {
             fn parse<'t>(
-                input: &mut oxvg_parse::Parser<'input, 't>,
-            ) -> Result<Self, oxvg_parse::error::ParseError<'input>> {
-                let location = input.current_source_location();
-                let ident = input.expect_ident()?;
-                let str: &str = &*ident;
+                input: &mut oxvg_parse::Parser<'input>,
+            ) -> Result<Self, oxvg_parse::error::Error<'input>> {
+                let str = input.expect_ident()?;
                 match str {
                     $($value => Ok($attr::$name),)+
-                    _ => Err(location.new_unexpected_token_error(
-                        cssparser_lightningcss::Token::Ident(ident.clone())
-                    ))
+                    received => Err(oxvg_parse::error::Error::ExpectedIdent {
+                        expected: concat!("one of", $(" `", $value, "`"),+),
+                        received,
+                    })
                 }
             }
         }
@@ -2640,7 +2639,7 @@ try_from_into_property! {
     Font(value) => Inheritable::Defined(value) => value.option().ok_or(())?,
     FontFamily(value) => Inheritable::Defined(FontFamily(ListOf {
         list: value,
-        seperator: Comma,
+        seperator: SpaceOrComma,
     })) => value.option().ok_or(())?.0.list,
     FontSize(value) => Inheritable::Defined(value) => value.option().ok_or(())?,
     FontStretch(value) => Inheritable::Defined(value) => value.option().ok_or(())?,
@@ -2654,7 +2653,7 @@ try_from_into_property! {
     Marker(value) => Inheritable::Defined(value) => value.option().ok_or(())?,
     Mask(value, vp) => Inheritable::Defined(Mask(ListOf {
         list: value.to_vec(),
-        seperator: Comma,
+        seperator: SpaceOrComma,
     })) => value.option().ok_or(())?.0.list.into(),
     Opacity(value) => Inheritable::Defined(value) => value.option().ok_or(())?,
     Overflow(value) => Inheritable::Defined(value) => value.option().ok_or(())?,

--- a/crates/oxvg_collections/src/attribute/path.rs
+++ b/crates/oxvg_collections/src/attribute/path.rs
@@ -1,6 +1,8 @@
 //! Path data attributes as specified in [paths](https://svgwg.org/svg2-draft/paths.html#DProperty)
 use std::ops::Deref;
 
+#[cfg(feature = "parse")]
+use oxvg_parse::{error::Error, Parse, Parser};
 #[cfg(feature = "serialize")]
 use oxvg_serialize::{error::PrinterError, Printer, ToValue};
 
@@ -10,14 +12,14 @@ use oxvg_serialize::{error::PrinterError, Printer, ToValue};
 /// [w3 | SVG 1.1](https://www.w3.org/TR/2011/REC-SVG11-20110816/paths.html#PathData)
 /// [w3 | SVG 2](https://svgwg.org/svg2-draft/paths.html#DProperty)
 pub struct Path(pub oxvg_path::Path);
-impl Path {
+impl<'input> Parse<'input> for Path {
     // TODO: implement ToCss compatible method
     /// Parse a value from a string
     ///
     /// # Errors
     /// If parsing fails
-    pub fn parse_string(definition: &str) -> Result<Self, oxvg_path::parser::Error> {
-        oxvg_path::Path::parse_string(definition).map(Self)
+    fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>> {
+        oxvg_path::Path::parse(input).map(Self)
     }
 }
 #[cfg(feature = "serialize")]
@@ -48,17 +50,14 @@ impl ToValue for Path {
 /// [SVG 1.1](https://www.w3.org/TR/2011/REC-SVG11-20110816/shapes.html#PointsBNF)
 /// [SVG 2](https://svgwg.org/svg2-draft/shapes.html#PolylineElementPointsAttribute)
 pub struct Points(pub oxvg_path::Path);
-impl Points {
-    // TODO: implement ToCss compatible method
-    /// Parse a value from a string
-    ///
-    /// # Errors
-    /// If parsing fails
-    pub fn parse_string(definition: &str) -> Result<Self, oxvg_path::parser::Error> {
-        oxvg_path::Path::parse_string(&format!("M{definition}")).map(Self)
+#[cfg(feature = "parse")]
+impl<'input> Parse<'input> for Points {
+    fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>> {
+        let mut result = oxvg_path::Path(vec![]);
+        result.parse_extend(input, true)?;
+        Ok(Self(result))
     }
 }
-
 impl Deref for Path {
     type Target = oxvg_path::Path;
 

--- a/crates/oxvg_collections/src/content_type.rs
+++ b/crates/oxvg_collections/src/content_type.rs
@@ -203,7 +203,7 @@ impl<'input> ContentType<'_, 'input> {
             Self::SVGTransformList(transform_list) => transform_list.0.is_empty(),
             Self::ListOf(ListOf { list, .. }) => list.is_empty(),
             Self::ColorProfile(color_profile) => match &**color_profile {
-                ColorProfile::Name(value) | ColorProfile::IRI(value) => value.is_empty(),
+                ColorProfile::NameOrIRI(value) => value.is_empty(),
                 _ => false,
             },
             Self::ColorProfileName(color_profile_name) => match &**color_profile_name {
@@ -260,7 +260,7 @@ impl<'input> ContentType<'_, 'input> {
         use lightningcss::values::url::Url;
         use std::marker::PhantomData;
         match self {
-            Self::ColorProfile(ContentTypeRef::RefMut(ColorProfile::IRI(url))) => {
+            Self::ColorProfile(ContentTypeRef::RefMut(ColorProfile::NameOrIRI(url))) => {
                 f(Reference::Atom(url));
             }
             Self::FuncIRI(ContentTypeRef::RefMut(url)) | Self::Url(ContentTypeRef::RefMut(url)) => {

--- a/crates/oxvg_collections/src/name.rs
+++ b/crates/oxvg_collections/src/name.rs
@@ -175,6 +175,16 @@ macro_rules! define_prefix {
                 }
             }
         }
+
+        impl PartialEq for NS<'_> {
+            fn eq(&self, other: &Self) -> bool {
+                match (self, other) {
+                    $((Self::$prefix, Self::$prefix) => true,)+
+                    (Self::Unknown(uri), Self::Unknown(other_uri)) => uri == other_uri,
+                    _ => false,
+                }
+            }
+        }
     };
 }
 
@@ -199,11 +209,6 @@ impl Display for QualName<'_> {
 impl PartialOrd for NS<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.uri().partial_cmp(other.uri())
-    }
-}
-impl PartialEq for NS<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.uri().eq(other.uri())
     }
 }
 

--- a/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
+++ b/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
@@ -170,7 +170,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ApplyTransforms {
         };
         let path = &mut d.0;
         apply_matrix_to_path_data(path, &matrix);
-        *path = convert::cleanup_unpositioned(path);
+        convert::cleanup_unpositioned(path);
         log::debug!("new d <- {path}");
         drop(d);
         element.remove_attribute(&AttrId::Transform);

--- a/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
@@ -147,7 +147,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertPathData {
             return Ok(());
         }
 
-        *path = convert::run(
+        convert::run(
             path,
             &convert::Options {
                 flags: self.into(),

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_transform__convert_transform-4.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__convert_transform__convert_transform-4.snap
@@ -14,5 +14,5 @@ expression: "test_config(r#\"{ \"convertTransform\": {} }\"#,\nSome(r#\"<svg xml
     <g/>
     <g/>
     <g/>
-    <g transform="rotate(45 34 34)"/>
+    <g transform="rotate(45, 34, 34"/>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-7.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-7.snap
@@ -6,7 +6,7 @@ expression: "test_config(r#\"{ \"minifyStyles\": {} }\"#,\nSome(r#\"<svg xmlns=\
     <style>
         .used{p:1}.unused{p:2}
     </style>
-    <g class="used" onclick="">
+    <g class="used" onclick="/* on* attributes prevents removing unused styles */">
         test
     </g>
 </svg>

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-8.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__minify_styles__minify_styles-8.snap
@@ -9,7 +9,7 @@ expression: "test_config(r#\"{ \"minifyStyles\": { \"removeUnused\": \"force\" }
     <script>
         /* with usage.force=true script element does not prevent removing unused styles */
     </script>
-    <g class="used" onclick="">
+    <g class="used" onclick="/* with usage.force=true on* attributes doesn't prevent removing unused styles */">
         test
     </g>
 </svg>

--- a/crates/oxvg_parse/Cargo.toml
+++ b/crates/oxvg_parse/Cargo.toml
@@ -12,6 +12,11 @@ description = "Parsing primitives for SVG"
 [lints]
 workspace = true
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+lightningcss = ["dep:cssparser_lightningcss", "dep:lightningcss"]
+
 [dependencies]
-cssparser_lightningcss = { workspace = true }
-lightningcss = { workspace = true }
+cssparser_lightningcss = { workspace = true, optional = true }
+lightningcss = { workspace = true, optional = true }

--- a/crates/oxvg_parse/src/lib.rs
+++ b/crates/oxvg_parse/src/lib.rs
@@ -1,11 +1,264 @@
 //! Primitives for parsing XML values
 
-use crate::error::{ParseError, ParseErrorKind};
+use error::Error;
+mod types;
 
 pub mod error;
 
-/// A parser for CSS and attribute values
-pub type Parser<'input, 't> = cssparser_lightningcss::Parser<'input, 't>;
+/// A parser containing state for the active parsing of an SVG value
+pub struct Parser<'input> {
+    input: &'input str,
+    cursor: usize,
+}
+
+impl<'input> Parser<'input> {
+    /// Create a new parser with the input
+    pub fn new(input: &'input str) -> Self {
+        Self { input, cursor: 0 }
+    }
+
+    /// Returns the current position in the input being read
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Try reading the next value
+    ///
+    /// # Errors
+    ///
+    /// If the input has ended
+    pub fn read(&mut self) -> Result<char, Error<'input>> {
+        let current = self.current()?;
+        self.advance();
+        Ok(current)
+    }
+
+    /// Go to the next value without reading
+    pub fn advance(&mut self) {
+        self.cursor += 1;
+    }
+
+    /// Move backwards without reading
+    pub fn rewind(&mut self, n: usize) {
+        self.cursor -= n;
+    }
+
+    /// Skip remaining input
+    pub fn done(&mut self) {
+        self.cursor = self.input.len();
+    }
+
+    /// Try parsing a portion of the input, reverting to the original state if failed
+    ///
+    /// # Errors
+    ///
+    /// If the attempted parsing fails
+    pub fn try_parse<T, E, F: FnOnce(&mut Self) -> Result<T, E>>(&mut self, f: F) -> Result<T, E> {
+        let cursor = self.cursor;
+        let result = f(self);
+        if result.is_err() {
+            self.cursor = cursor;
+        }
+        result
+    }
+
+    /// Get remaining slice of input
+    pub fn slice(&self) -> &'input str {
+        &self.input[self.cursor..]
+    }
+
+    /// Get remaining slice of input and advance to the end of the input
+    pub fn take_slice(&mut self) -> &'input str {
+        let slice = &self.input[self.cursor..];
+        self.done();
+        slice
+    }
+
+    /// Get slice from start position to current position
+    pub fn slice_from(&self, start: usize) -> &'input str {
+        let end = self.cursor.min(self.input.len());
+        &self.input[start..end]
+    }
+
+    /// Get the length of the remaining input
+    pub fn len(&self) -> usize {
+        self.input.len() - self.cursor
+    }
+
+    /// Returns whether the remaining input is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Gets the current character of the input
+    ///
+    /// # Errors
+    ///
+    /// If reached the end of input
+    pub fn current(&self) -> Result<char, Error<'input>> {
+        self.slice().chars().next().ok_or(Error::EndOfInput)
+    }
+
+    /// Move the cursor forward while the characters match the given predicate
+    ///
+    /// Returns the skipped content as a slice
+    pub fn take_matches<F: FnMut(char) -> bool>(&mut self, f: F) -> &'input str {
+        let cursor = self.cursor();
+        self.skip_matches(f);
+        let result = self.slice_from(cursor);
+        result
+    }
+
+    /// Moves the cursor forward the number of matching characters
+    pub fn skip_matches<F: FnMut(char) -> bool>(&mut self, pat: F) {
+        self.skip_internal(self.slice().trim_start_matches(pat).len());
+    }
+
+    /// Moves the cursor forward the number of matching characters
+    pub fn skip_char(&mut self, char: char) {
+        self.skip_internal(self.slice().trim_matches(char).len());
+    }
+
+    /// Moves the cursor forward the number of whitespace characters
+    pub fn skip_whitespace(&mut self) {
+        self.skip_matches(char::is_whitespace);
+    }
+
+    fn skip_internal(&mut self, trim: usize) {
+        let offset = self.len() - trim;
+        self.cursor += offset;
+    }
+
+    /// Asserts the end of the input was reached
+    ///
+    /// # Errors
+    ///
+    /// When the cursor is prior to the end of the string
+    pub fn expect_done(&self) -> Result<(), Error<'input>> {
+        if self.cursor < self.input.len() {
+            Err(Error::ExpectedDone)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Read and assert the next character matches the expected character
+    ///
+    /// # Errors
+    ///
+    /// If the end of the input is reached, or the character does not match
+    pub fn expect_char(&mut self, expected: char) -> Result<(), Error<'input>> {
+        let received = self.read()?;
+        if received == expected {
+            Ok(())
+        } else {
+            Err(Error::ExpectedChar { expected, received })
+        }
+    }
+
+    /// Read and assert a set of characters matches the expected pattern.
+    ///
+    /// # Errors
+    ///
+    /// - If the end of the input is reached
+    /// - If none of the characters match the expected pattern
+    /// - If the patterns matcher asserts an error
+    pub fn expect_matches<F: Fn(char) -> Result<bool, &'static str>>(
+        &mut self,
+        expected: &'static str,
+        f: F,
+    ) -> Result<&'input str, Error<'input>> {
+        let cursor = self.cursor;
+        let mut result = Ok(());
+        self.skip_matches(|char| match f(char) {
+            Ok(bool) => bool,
+            Err(expected) => {
+                result = Err(expected);
+                false
+            }
+        });
+        match result {
+            Ok(()) => match self.slice_from(cursor) {
+                "" => Err(Error::ExpectedMatch {
+                    expected,
+                    received: "nothing",
+                }),
+                result => Ok(result),
+            },
+            Err(expected) => Err(Error::ExpectedMatch {
+                expected,
+                received: self.slice_from(cursor),
+            }),
+        }
+    }
+
+    /// Read and assert a set of characters is whitespace
+    ///
+    /// # Errors
+    ///
+    /// If none of the next characters are whitespace
+    pub fn expect_whitespace(&mut self) -> Result<(), Error<'input>> {
+        self.expect_matches("a whitespace character", |char| Ok(char.is_whitespace()))?;
+        Ok(())
+    }
+
+    /// Read and assert a set of characters matches the given string
+    ///
+    /// # Errors
+    ///
+    /// If the next set of characters does not match the given string
+    pub fn expect_str(&mut self, expected: &'static str) -> Result<(), Error<'input>> {
+        let cursor = self.cursor;
+        self.cursor += expected.len();
+        let received = self.slice_from(cursor);
+        if received == expected {
+            Ok(())
+        } else {
+            Err(Error::ExpectedString { expected, received })
+        }
+    }
+
+    /// Read and assert a set of characters matches some ident
+    ///
+    /// # Errors
+    ///
+    /// When an invalid ident is received
+    pub fn expect_ident(&mut self) -> Result<&'input str, Error<'input>> {
+        let cursor = self.cursor;
+        let name_start_char = self.read()?;
+        if !is_name_start_char(name_start_char) {
+            return Err(Error::ExpectedIdent {
+                expected: "valid ident starting character",
+                received: self.slice_from(cursor),
+            });
+        }
+        self.skip_matches(is_name_char);
+        Ok(self.slice_from(cursor))
+    }
+
+    /// Read and assert a set of characters matches the given identifier
+    ///
+    /// # Errors
+    ///
+    /// If the next set of characters does not match the given identifier
+    pub fn expect_ident_matching(&mut self, expected: &'static str) -> Result<(), Error<'input>> {
+        let received = self.expect_ident()?;
+        if received == expected {
+            Ok(())
+        } else {
+            Err(Error::ExpectedIdent { expected, received })
+        }
+    }
+}
+fn is_name_start_char(char: char) -> bool {
+    char.is_ascii_alphabetic()
+        || matches!(char, ':' | '_' | '\u{C0}'..'\u{D6}' | '\u{D8}'..='\u{F6}' | '\u{F8}'..='\u{2FF}' | '\u{370}'..='\u{37D}' | '\u{37F}'..='\u{1FFF}' | '\u{200C}'..='\u{200D}' | '\u{2070}'..='\u{218F}' | '\u{2C00}'..='\u{2FEF}' | '\u{3001}'..='\u{D7FF}' | '\u{F900}'..='\u{FDCF}' | '\u{FDF0}'..='\u{FFFD}' | '\u{10000}'..='\u{EFFFF}')
+}
+fn is_name_char(char: char) -> bool {
+    is_name_start_char(char)
+        || char.is_ascii_digit()
+        || matches!(char, '-' | '.' | '\u{B7}' | '\u{0300}'..='\u{036F}' | '\u{203F}'..='\u{2040}')
+}
 
 /// A trait for things that can be parsed from CSS or attribute values.
 pub trait Parse<'input>: Sized {
@@ -13,41 +266,18 @@ pub trait Parse<'input>: Sized {
     ///
     /// # Errors
     /// If parsing fails
-    fn parse<'t>(input: &mut Parser<'input, 't>) -> Result<Self, ParseError<'input>>;
+    fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>>;
 
     /// Parse a value from a string
     ///
     /// # Errors
     /// If parsing fails
-    fn parse_string(input: &'input str) -> Result<Self, ParseError<'input>> {
-        let mut input = cssparser_lightningcss::ParserInput::new(input);
-        let mut parser = cssparser_lightningcss::Parser::new(&mut input);
+    fn parse_string(input: &'input str) -> Result<Self, Error<'input>> {
+        let parser = &mut Parser::new(input);
         parser.skip_whitespace();
-        let result = Self::parse(&mut parser)?;
-        parser.expect_exhausted()?;
+        let result = Self::parse(parser)?;
+        parser.skip_whitespace();
+        parser.expect_done()?;
         Ok(result)
-    }
-}
-
-impl<'input, T> Parse<'input> for T
-where
-    T: lightningcss::traits::Parse<'input>,
-{
-    fn parse<'t>(input: &mut Parser<'input, 't>) -> Result<Self, ParseError<'input>> {
-        lightningcss::traits::Parse::parse(input).map_err(|err| {
-            cssparser_lightningcss::ParseError {
-                kind: match err.kind {
-                    cssparser_lightningcss::ParseErrorKind::Custom(err) => {
-                        cssparser_lightningcss::ParseErrorKind::Custom(
-                            ParseErrorKind::CSSParserError(err),
-                        )
-                    }
-                    cssparser_lightningcss::ParseErrorKind::Basic(err) => {
-                        cssparser_lightningcss::ParseErrorKind::Basic(err)
-                    }
-                },
-                location: err.location,
-            }
-        })
     }
 }

--- a/crates/oxvg_parse/src/types.rs
+++ b/crates/oxvg_parse/src/types.rs
@@ -1,0 +1,3 @@
+#[cfg(feature = "lightningcss")]
+pub mod lightningcss;
+pub mod number;

--- a/crates/oxvg_parse/src/types/lightningcss.rs
+++ b/crates/oxvg_parse/src/types/lightningcss.rs
@@ -1,0 +1,84 @@
+//! Parsing for lightningcss values
+use lightningcss::{
+    properties::{
+        display::{Display, Visibility},
+        effects::FilterList,
+        font::{Font, FontFamily, FontSize, FontStretch, FontStyle, FontWeight},
+        masking::{ClipPath, Mask, MaskType},
+        overflow::Overflow,
+        svg::{
+            ColorInterpolation, ColorRendering, ImageRendering, Marker, SVGPaint, ShapeRendering,
+            StrokeDasharray, StrokeLinecap, StrokeLinejoin, TextRendering,
+        },
+        text::{Direction, Spacing, TextDecoration, UnicodeBidi},
+        transform::Transform,
+        ui::Cursor,
+    },
+    values::{
+        alpha::AlphaValue,
+        angle::Angle,
+        color::CssColor,
+        length::{LengthOrNumber, LengthValue},
+        percentage::{DimensionPercentage, Percentage},
+        position::{
+            HorizontalPositionKeyword, Position, PositionComponent, VerticalPositionKeyword,
+        },
+        shape::FillRule,
+        time::Time,
+    },
+};
+
+use crate::{error::Error, Parse, Parser};
+
+macro_rules! impl_type {
+    ($ty:ty) => {
+        impl<'input> Parse<'input> for $ty {
+            fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>> {
+                <Self as lightningcss::traits::Parse>::parse_string(input.take_slice())
+                    .map_err(Error::Lightningcss)
+            }
+        }
+    };
+}
+
+impl_type!(AlphaValue);
+impl_type!(Angle);
+impl_type!(ClipPath<'input>);
+impl_type!(ColorInterpolation);
+impl_type!(ColorRendering);
+impl_type!(CssColor);
+impl_type!(Cursor<'input>);
+impl_type!(DimensionPercentage<LengthValue>);
+impl_type!(Direction);
+impl_type!(Display);
+impl_type!(FillRule);
+impl_type!(FilterList<'input>);
+impl_type!(Font<'input>);
+impl_type!(FontFamily<'input>);
+impl_type!(FontSize);
+impl_type!(FontStretch);
+impl_type!(FontStyle);
+impl_type!(FontWeight);
+impl_type!(ImageRendering);
+impl_type!(LengthOrNumber);
+impl_type!(LengthValue);
+impl_type!(Marker<'input>);
+impl_type!(Mask<'input>);
+impl_type!(MaskType);
+impl_type!(Overflow);
+impl_type!(Percentage);
+impl_type!(Position);
+impl_type!(PositionComponent<HorizontalPositionKeyword>);
+impl_type!(PositionComponent<VerticalPositionKeyword>);
+impl_type!(SVGPaint<'input>);
+impl_type!(ShapeRendering);
+impl_type!(Spacing);
+impl_type!(StrokeDasharray);
+impl_type!(StrokeLinecap);
+impl_type!(StrokeLinejoin);
+impl_type!(TextDecoration);
+impl_type!(TextRendering);
+impl_type!(Transform);
+impl_type!(Time);
+impl_type!(UnicodeBidi);
+impl_type!(Visibility);

--- a/crates/oxvg_parse/src/types/number.rs
+++ b/crates/oxvg_parse/src/types/number.rs
@@ -1,0 +1,113 @@
+//! Parsing for number values
+use crate::{error::Error, Parse, Parser};
+
+impl<'input> Parse<'input> for f64 {
+    fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>> {
+        input.skip_whitespace();
+
+        let cursor = input.cursor;
+        input.skip_matches(|char| matches!(char, '-' | '+'));
+        input.skip_matches(|char| char.is_ascii_digit());
+        input.skip_char('.');
+        input.skip_matches(|char| char.is_ascii_digit());
+
+        if let Ok('e' | 'E') = input.current() {
+            input.advance();
+            if let Ok('x' | 'm') = input.current() {
+                input.rewind(1);
+            } else {
+                let exponent_cursor = input.cursor;
+                input.skip_matches(|char| matches!(char, '-' | '+'));
+                input.skip_matches(|char| char.is_ascii_digit());
+                input.skip_char('.');
+                input.skip_matches(|char| char.is_ascii_digit());
+                if exponent_cursor == input.cursor {
+                    return Err(Error::InvalidNumber);
+                }
+            }
+        }
+
+        let number: f64 = input
+            .slice_from(cursor)
+            .parse()
+            .map_err(|_| Error::InvalidNumber)?;
+        if number.is_finite() {
+            Ok(number)
+        } else {
+            Err(Error::InvalidNumber)
+        }
+    }
+}
+
+impl<'input> Parse<'input> for f32 {
+    fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>> {
+        Ok(f64::parse(input)? as f32)
+    }
+}
+
+impl<'input> Parse<'input> for i64 {
+    fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>> {
+        input.skip_whitespace();
+
+        let cursor = input.cursor;
+        input.skip_matches(|char| matches!(char, '-' | '+'));
+        input.skip_matches(|char| char.is_ascii_digit());
+
+        let number: i64 = input
+            .slice_from(cursor)
+            .parse()
+            .map_err(|_| Error::InvalidNumber)?;
+        Ok(number)
+    }
+}
+
+impl<'input> Parse<'input> for i32 {
+    fn parse(input: &mut Parser<'input>) -> Result<Self, Error<'input>> {
+        Ok(i64::parse(input)? as i32)
+    }
+}
+
+#[test]
+fn float() {
+    assert_eq!(f64::parse_string("0"), Ok(0.0));
+    assert_eq!(f64::parse_string("1"), Ok(1.0));
+    assert_eq!(f64::parse_string("-1"), Ok(-1.0));
+    assert_eq!(f64::parse_string(" -1 "), Ok(-1.0));
+    assert_eq!(f64::parse_string("  1  "), Ok(1.0));
+    assert_eq!(f64::parse_string(".4"), Ok(0.4));
+    assert_eq!(f64::parse_string("-.4"), Ok(-0.4));
+    assert_eq!(f64::parse_string(".0000000000008"), Ok(0.000_000_000_000_8));
+    assert_eq!(f64::parse_string("1000000000000"), Ok(1_000_000_000_000.0));
+    assert_eq!(f64::parse_string("123456.123456"), Ok(123_456.123_456));
+    assert_eq!(f64::parse_string("+10"), Ok(10.0));
+    assert_eq!(f64::parse_string("1e2"), Ok(100.0));
+    assert_eq!(f64::parse_string("1e+2"), Ok(100.0));
+    assert_eq!(f64::parse_string("1E2"), Ok(100.0));
+    assert_eq!(f64::parse_string("1e-2"), Ok(0.01));
+    assert_eq!(
+        f64::parse_string("12345678901234567890"),
+        Ok(12_345_678_901_234_567_000.0)
+    );
+    assert_eq!(f64::parse_string("0."), Ok(0.0));
+    assert_eq!(f64::parse_string("1.3e-2"), Ok(0.013));
+
+    assert_eq!(f64::parse_string("-.4text"), Err(Error::ExpectedDone));
+    assert_eq!(f64::parse_string("-.01 text"), Err(Error::ExpectedDone));
+    assert_eq!(f64::parse_string("-.01 4"), Err(Error::ExpectedDone));
+    assert_eq!(f64::parse_string("1ex"), Err(Error::ExpectedDone));
+    assert_eq!(f64::parse_string("1em"), Err(Error::ExpectedDone));
+    assert_eq!(f64::parse_string("q"), Err(Error::InvalidNumber));
+    assert_eq!(f64::parse_string(""), Err(Error::InvalidNumber));
+    assert_eq!(f64::parse_string("-"), Err(Error::InvalidNumber));
+    assert_eq!(f64::parse_string("+"), Err(Error::InvalidNumber));
+    assert_eq!(f64::parse_string("-q"), Err(Error::InvalidNumber));
+    assert_eq!(f64::parse_string("."), Err(Error::InvalidNumber));
+    assert_eq!(
+        f64::parse_string("99999999e99999999"),
+        Err(Error::InvalidNumber)
+    );
+    assert_eq!(
+        f64::parse_string("-99999999e99999999"),
+        Err(Error::InvalidNumber)
+    );
+}

--- a/crates/oxvg_path/Cargo.toml
+++ b/crates/oxvg_path/Cargo.toml
@@ -19,11 +19,12 @@ format = ["ryu"]
 jsonschema = ["schemars", "serde"]
 napi = ["dep:napi", "dep:napi-derive"]
 optimise = ["format", "bitflags"]
-parse = ["bitflags"]
+parse = ["dep:oxvg_parse", "bitflags"]
 serde = ["dep:serde"]
 wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "dep:tsify"]
 
 [dependencies]
+oxvg_parse = { workspace = true, optional = true }
 bitflags = { workspace = true, optional = true }
 log = { workspace = true }
 napi = { workspace = true, optional = true }

--- a/crates/oxvg_path/Cargo.toml
+++ b/crates/oxvg_path/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["parse", "format", "optimise"]
-format = ["ryu"]
+format = ["ryu", "itertools"]
 jsonschema = ["schemars", "serde"]
 napi = ["dep:napi", "dep:napi-derive"]
 optimise = ["format", "bitflags"]
@@ -26,6 +26,7 @@ wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "dep:tsify"]
 [dependencies]
 oxvg_parse = { workspace = true, optional = true }
 bitflags = { workspace = true, optional = true }
+itertools = { workspace = true, optional = true }
 log = { workspace = true }
 napi = { workspace = true, optional = true }
 napi-derive = { workspace = true, optional = true }

--- a/crates/oxvg_path/src/convert/filter.rs
+++ b/crates/oxvg_path/src/convert/filter.rs
@@ -52,14 +52,13 @@ impl<'a> State<'a> {
 ///
 /// # Panics
 /// If the path length changes while running
-pub fn filter(
-    path: &Path,
-    options: &convert::Options,
-    state: &mut State,
-    info: &StyleInfo,
-) -> Path {
-    let mut new_path: Vec<_> = path.0.clone().into_iter().map(Some).collect();
-    (0..path.0.len()).for_each(|index| {
+pub fn filter(path: Path, options: &convert::Options, state: &mut State, info: &StyleInfo) -> Path {
+    #[cfg(debug_assertions)]
+    let path_dbg = path.to_string();
+
+    let len = path.0.len();
+    let mut new_path: Vec<_> = path.0.into_iter().map(Some).collect();
+    (0..len).for_each(|index| {
         if index > 0 {
             state.relative_subpoints[index] = state.relative_subpoints[index - 1];
         }
@@ -117,8 +116,7 @@ pub fn filter(
     let result = Path(new_path.into_iter().flatten().collect());
     #[cfg(debug_assertions)]
     {
-        let path_dbg = path.clone().take().to_string();
-        let result_dbg = result.clone().take().to_string();
+        let result_dbg = result.to_string();
         if path_dbg != result_dbg {
             log::debug!("convert::filter: updated path {result_dbg}");
         }

--- a/crates/oxvg_path/src/convert/filter/from.rs
+++ b/crates/oxvg_path/src/convert/filter/from.rs
@@ -60,7 +60,7 @@ fn make_specific_longhand(next: &mut Option<Position>, id: &command::ID, data: &
     if &next.command.id() != id {
         return;
     };
-    next.command = next.command.make_longhand(data);
+    next.command.make_longhand(data);
 }
 
 pub fn c_to_q(

--- a/crates/oxvg_path/src/convert/mixed.rs
+++ b/crates/oxvg_path/src/convert/mixed.rs
@@ -8,9 +8,13 @@ use crate::{
 ///
 /// # Panics
 /// If internal assertions fail
-pub fn mixed(path: &Path, options: &convert::Options) -> Path {
-    let mut new_path: Vec<_> = path.0.clone().into_iter().map(Some).collect();
-    (0..new_path.len()).for_each(|index| {
+pub fn mixed(path: Path, options: &convert::Options) -> Path {
+    #[cfg(debug_assertions)]
+    let path_dbg = path.to_string();
+
+    let len = path.0.len();
+    let mut new_path: Vec<_> = path.0.into_iter().map(Some).collect();
+    (0..len).for_each(|index| {
         let Some((prev, item_option, _)) = Path::split_mut(&mut new_path, index)
         else {
             return;
@@ -61,8 +65,7 @@ pub fn mixed(path: &Path, options: &convert::Options) -> Path {
     let result = Path(new_path.into_iter().flatten().collect());
     #[cfg(debug_assertions)]
     {
-        let path_dbg = path.clone().take().to_string();
-        let result_dbg = result.clone().take().to_string();
+        let result_dbg = result.to_string();
         if path_dbg != result_dbg {
             log::debug!("convert::mixed: updated path: {result_dbg}");
         }

--- a/crates/oxvg_path/src/convert/mod.rs
+++ b/crates/oxvg_path/src/convert/mod.rs
@@ -112,6 +112,7 @@ pub struct Options {
 /// ```
 /// use oxvg_path::Path;
 /// use oxvg_path::convert::{Options, StyleInfo, run};
+/// use oxvg_path::parser::Parse as _;
 ///
 /// let path = Path::parse_string("M 10,50 L 10,50").unwrap();
 /// let options = Options::default();
@@ -334,6 +335,7 @@ impl Precision {
 #[test]
 fn test_convert() {
     use crate::Path;
+    use oxvg_parse::Parse as _;
 
     let mut path = Path::parse_string("m 1208.23,1821.01 c 74.07,14.24 196.57,17.09 293.43,-14.24 122.5,-42.74 22.79,-199.42 48.43,-207.97 25.64,-8.55 59.83,108.25 287.73,96.86 230.75,-11.39 256.39,-113.95 287.73,-96.86 31.34,17.09 -31.34,284.88 313.37,222.21 0,0 -361.8,96.86 -344.71,-165.23 0,0 -207.96,159.53 -498.54,17.09 2.85,0 76.92,245 -387.44,148.14").unwrap();
     path = run(&path, &Options::default(), &StyleInfo::default());

--- a/crates/oxvg_path/src/convert/mod.rs
+++ b/crates/oxvg_path/src/convert/mod.rs
@@ -114,14 +114,14 @@ pub struct Options {
 /// use oxvg_path::convert::{Options, StyleInfo, run};
 /// use oxvg_path::parser::Parse as _;
 ///
-/// let path = Path::parse_string("M 10,50 L 10,50").unwrap();
+/// let mut path = Path::parse_string("M 10,50 L 10,50").unwrap();
 /// let options = Options::default();
 /// let style_info = StyleInfo::conservative();
 ///
-/// let path = run(&path, &options, &style_info);
+/// run(&mut path, &options, &style_info);
 /// assert_eq!(&path.to_string(), "M10 50h0");
 /// ```
-pub fn run(path: &Path, options: &Options, style_info: &StyleInfo) -> Path {
+pub fn run(path: &mut Path, options: &Options, style_info: &StyleInfo) {
     let includes_vertices = path
         .0
         .iter()
@@ -129,13 +129,13 @@ pub fn run(path: &Path, options: &Options, style_info: &StyleInfo) -> Path {
     // The general optimisation process: original -> naively relative -> filter redundant ->
     // optimal mixed
     log::debug!("convert::run: converting path: {path}");
-    let mut positioned_path = relative(path);
+    let mut positioned_path = relative(std::mem::take(path));
     let mut state = filter::State::new(&positioned_path, options, style_info);
-    positioned_path = filter(&positioned_path, options, &mut state, style_info);
+    positioned_path = filter(positioned_path, options, &mut state, style_info);
     if options.flags.utilize_absolute() {
-        positioned_path = mixed(&positioned_path, options);
+        positioned_path = mixed(positioned_path, options);
     }
-    positioned_path = cleanup(&positioned_path);
+    positioned_path = cleanup(positioned_path);
     for command in &mut positioned_path.0 {
         if command.command.is_by() {
             options.round_data(command.command.args_mut(), options.error());
@@ -148,7 +148,7 @@ pub fn run(path: &Path, options: &Options, style_info: &StyleInfo) -> Path {
         }
     }
 
-    let mut path = positioned_path.take();
+    *path = positioned_path.take();
     let has_marker = style_info.contains(StyleInfo::has_marker);
     let is_markers_only_path = has_marker
         && includes_vertices
@@ -160,7 +160,6 @@ pub fn run(path: &Path, options: &Options, style_info: &StyleInfo) -> Path {
         path.0.push(command::Data::ClosePath);
     }
     log::debug!("convert::run: done: {path}");
-    path
 }
 
 impl StyleInfo {
@@ -338,7 +337,7 @@ fn test_convert() {
     use oxvg_parse::Parse as _;
 
     let mut path = Path::parse_string("m 1208.23,1821.01 c 74.07,14.24 196.57,17.09 293.43,-14.24 122.5,-42.74 22.79,-199.42 48.43,-207.97 25.64,-8.55 59.83,108.25 287.73,96.86 230.75,-11.39 256.39,-113.95 287.73,-96.86 31.34,17.09 -31.34,284.88 313.37,222.21 0,0 -361.8,96.86 -344.71,-165.23 0,0 -207.96,159.53 -498.54,17.09 2.85,0 76.92,245 -387.44,148.14").unwrap();
-    path = run(&path, &Options::default(), &StyleInfo::default());
+    run(&mut path, &Options::default(), &StyleInfo::default());
     assert_eq!(
         String::from(path),
         String::from("M1208.23 1821.01c74.07 14.24 196.57 17.09 293.43-14.24 122.5-42.74 22.79-199.42 48.43-207.97s59.83 108.25 287.73 96.86c230.75-11.39 256.39-113.95 287.73-96.86s-31.34 284.88 313.37 222.21c0 0-361.8 96.86-344.71-165.23 0 0-207.96 159.53-498.54 17.09 2.85 0 76.92 245-387.44 148.14")

--- a/crates/oxvg_path/src/convert/relative.rs
+++ b/crates/oxvg_path/src/convert/relative.rs
@@ -1,15 +1,17 @@
 use crate::{command, geometry::Point, positioned, Path};
 
 /// Convert absolute path data coordinates to relative
-pub fn relative(path: &Path) -> positioned::Path {
-    let new_path = path;
+pub fn relative(path: Path) -> positioned::Path {
+    #[cfg(debug_assertions)]
+    let original_dbg = path.to_string();
+
+    let path = path;
     let start = &mut Point([0.0; 2]);
     let cursor = &mut Point([0.0; 2]);
 
     let result = positioned::Path(
-        new_path
-            .0
-            .iter()
+        path.0
+            .into_iter()
             .enumerate()
             .map(|(i, item)| convert_command_to_relative(item, start, cursor, i == 0))
             .collect(),
@@ -17,11 +19,8 @@ pub fn relative(path: &Path) -> positioned::Path {
     #[cfg(debug_assertions)]
     {
         let result_dbg = result.clone().take().to_string();
-        if path.to_string() != result_dbg {
-            log::debug!(
-                "convert::relative: {} changed to {result_dbg}",
-                path.to_string()
-            );
+        if original_dbg != result_dbg {
+            log::debug!("convert::relative: {original_dbg} changed to {result_dbg}",);
         }
     }
     result
@@ -29,12 +28,11 @@ pub fn relative(path: &Path) -> positioned::Path {
 
 #[allow(clippy::too_many_lines)]
 fn convert_command_to_relative(
-    command: &command::Data,
+    mut command: command::Data,
     start: &mut Point,
     cursor: &mut Point,
     is_first: bool,
 ) -> command::Position {
-    let mut command = command.clone();
     let base = *cursor;
     match command {
         command::Data::MoveBy(a) => {
@@ -154,7 +152,7 @@ fn convert_command_to_relative(
             cursor.0[1] = start.0[1];
         }
         command::Data::Implicit(command) => {
-            return convert_command_to_relative(&command, start, cursor, is_first);
+            return convert_command_to_relative(*command, start, cursor, is_first);
         }
     };
     command::Position {
@@ -171,7 +169,7 @@ fn test_convert_relative() {
     use oxvg_parse::Parse as _;
 
     let mut path = Path::parse_string("M 10,50 C 20,30 40,50 60,70 C 10,20 30,40 50,60").unwrap();
-    path = Path::from(relative(&path));
+    path = Path::from(relative(path));
     assert_eq!(
         String::from(path),
         String::from("M10 50c10-20 30 0 50 20c-50-50-30-30-10-10")

--- a/crates/oxvg_path/src/convert/relative.rs
+++ b/crates/oxvg_path/src/convert/relative.rs
@@ -168,6 +168,7 @@ fn convert_command_to_relative(
 #[test]
 fn test_convert_relative() {
     use crate::Path;
+    use oxvg_parse::Parse as _;
 
     let mut path = Path::parse_string("M 10,50 C 20,30 40,50 60,70 C 10,20 30,40 50,60").unwrap();
     path = Path::from(relative(&path));

--- a/crates/oxvg_path/src/lib.rs
+++ b/crates/oxvg_path/src/lib.rs
@@ -42,9 +42,6 @@ pub mod positioned;
 
 use points::{Point, Points};
 
-#[cfg(feature = "parse")]
-use crate::parser::Parser;
-
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
@@ -55,7 +52,7 @@ use crate::parser::Parser;
 /// Out of the box, parsing and serializing a path will produce optimal formatting
 ///
 /// ```
-/// use oxvg_path::Path;
+/// use oxvg_path::{Path, parser::Parse as _};
 ///
 /// let path = Path::parse_string("M 10 0.01 L 0.5 -1").unwrap();
 /// assert_eq!(&path.to_string(), "M10 .01.5-1");
@@ -65,15 +62,6 @@ use crate::parser::Parser;
 pub struct Path(pub Vec<command::Data>);
 
 impl Path {
-    #[cfg(feature = "parse")]
-    /// Parses a path definition from a string
-    ///
-    /// # Errors
-    /// If the definition is invalid
-    pub fn parse_string(definition: &str) -> Result<Self, parser::Error> {
-        Parser::default().parse(definition)
-    }
-
     /// Checks if two paths have an intersection by checking convex hulls collision using
     /// Gilbert-Johnson-Keerthi distance algorithm.
     ///
@@ -183,6 +171,7 @@ impl From<&Path> for String {
 #[test]
 #[cfg(feature = "default")]
 fn test_path_parse() {
+    use oxvg_parse::Parse as _;
     // Should parse single command
     insta::assert_snapshot!(Path::parse_string("M 10,50").unwrap());
 

--- a/crates/oxvg_path/src/points.rs
+++ b/crates/oxvg_path/src/points.rs
@@ -348,6 +348,7 @@ impl Point {
 #[test]
 #[allow(clippy::too_many_lines)]
 fn from_positioned() {
+    use oxvg_parse::Parse as _;
     let path = convert::relative(&Path::parse_string("m10 10 m 10 10").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
@@ -528,7 +529,8 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 c20 0 15 -80 40 -80 s20 80 40 80").unwrap());
+    let path =
+        convert::relative(&Path::parse_string("m10 10 c20 0 15 -80 40 -80 s20 80 40 80").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -586,8 +588,9 @@ fn from_positioned() {
         )
     );
 
-    let path =
-        convert::relative(&Path::parse_string("m10 10 q25 25 40 50 t30 0 30 0 30 0 30 0 30 0").unwrap());
+    let path = convert::relative(
+        &Path::parse_string("m10 10 q25 25 40 50 t30 0 30 0 30 0 30 0 30 0").unwrap(),
+    );
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),

--- a/crates/oxvg_path/src/points.rs
+++ b/crates/oxvg_path/src/points.rs
@@ -39,7 +39,7 @@ pub struct Point {
 
 impl Points {
     /// Creates the list of points from a path.
-    pub fn from_path(path: &Path) -> Self {
+    pub fn from_path(path: Path) -> Self {
         Self::from_positioned(&convert::relative(path))
     }
 
@@ -241,10 +241,11 @@ impl Points {
 }
 
 impl Point {
+    #[must_use]
     /// Forms a convex hull from set of points of every subpath using monotone chain convex hull
     /// algorithm.
-    pub fn convex_hull(&self) -> Self {
-        let mut list = self.list.clone();
+    pub fn convex_hull(self) -> Self {
+        let mut list = self.list;
         list.sort_by(|geometry::Point(a), geometry::Point(b)| {
             if a[0] == b[0] {
                 a[1].total_cmp(&b[1])
@@ -272,7 +273,7 @@ impl Point {
         }
 
         let mut upper = vec![];
-        let mut max_y = self.list.len() - 1;
+        let mut max_y = list.len() - 1;
         let mut top = 0;
 
         for (i, point) in list.iter().enumerate().rev() {
@@ -349,7 +350,7 @@ impl Point {
 #[allow(clippy::too_many_lines)]
 fn from_positioned() {
     use oxvg_parse::Parse as _;
-    let path = convert::relative(&Path::parse_string("m10 10 m 10 10").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 m 10 10").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -380,7 +381,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 l 10 10").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 l 10 10").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -402,7 +403,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 h 10").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 h 10").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -424,7 +425,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 v 10").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 v 10").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -446,7 +447,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 c20 0 15 -80 40 -80").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 c20 0 15 -80 40 -80").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -474,7 +475,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 s20 80 40 80").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 s20 80 40 80").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -501,7 +502,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 c20 0 15 -80 40 -80").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 c20 0 15 -80 40 -80").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -530,7 +531,7 @@ fn from_positioned() {
     );
 
     let path =
-        convert::relative(&Path::parse_string("m10 10 c20 0 15 -80 40 -80 s20 80 40 80").unwrap());
+        convert::relative(Path::parse_string("m10 10 c20 0 15 -80 40 -80 s20 80 40 80").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -562,7 +563,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 q25 25 40 50").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 q25 25 40 50").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),
@@ -589,7 +590,7 @@ fn from_positioned() {
     );
 
     let path = convert::relative(
-        &Path::parse_string("m10 10 q25 25 40 50 t30 0 30 0 30 0 30 0 30 0").unwrap(),
+        Path::parse_string("m10 10 q25 25 40 50 t30 0 30 0 30 0 30 0 30 0").unwrap(),
     );
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
@@ -626,7 +627,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 a 6 4 10 1 0 14 10").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 a 6 4 10 1 0 14 10").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:.12?}"),
@@ -658,7 +659,7 @@ fn from_positioned() {
         )
     );
 
-    let path = convert::relative(&Path::parse_string("m10 10 l10 10 h10 v10 c20 0 15 -80 40 -80 s20 80 40 80 q25 25 40 50 t30 0 30 0 30 0 30 0 30 0 a 6 4 10 1 0 14 10 z").unwrap());
+    let path = convert::relative(Path::parse_string("m10 10 l10 10 h10 v10 c20 0 15 -80 40 -80 s20 80 40 80 q25 25 40 50 t30 0 30 0 30 0 30 0 30 0 a 6 4 10 1 0 14 10 z").unwrap());
     let points = Points::from_positioned(&path);
     pretty_assertions::assert_eq!(
         format!("{points:#?}"),

--- a/crates/oxvg_path/src/positioned.rs
+++ b/crates/oxvg_path/src/positioned.rs
@@ -19,9 +19,8 @@ type SplitPositionedPathWithPrevOption<'a> = (
 
 impl Path {
     /// Converts self into a [Path](Path), emptying self in the process
-    pub fn take(&mut self) -> crate::Path {
-        let entries = std::mem::take(&mut self.0);
-        crate::Path(entries.into_iter().map(|p| p.command).collect())
+    pub fn take(self) -> crate::Path {
+        crate::Path(self.0.into_iter().map(|p| p.command).collect())
     }
 
     /// Split by `[...prev_paths, prev, item, ...next_paths]`
@@ -71,15 +70,8 @@ impl Path {
     }
 }
 
-#[cfg(feature = "format")]
-impl std::fmt::Display for Path {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        crate::Path(self.0.iter().map(|p| p.command.clone()).collect()).fmt(f)
-    }
-}
-
 impl From<Path> for crate::Path {
     fn from(value: Path) -> Self {
-        Self(value.0.iter().map(|p| p.command.clone()).collect())
+        value.take()
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

Updates parsing on non-css attribute values that don’t need tokenisation with csssparser.

## Motivation and Context

Further improves performance of parsing documents and reduces the risk of data-loss.

Given we usually know the exact type and length of an input, we can pull from the value as-is. 

## How Has This Been Tested?

- Unit tests
- w3c & oxygen

```mermaid
---
config:
    xyChart:
        width: 622
        height: 181

---
xychart horizontal
    title "Performance change (ms)"
    x-axis [Oxygen, w3c]
    y-axis "Time (ms)" 0 --> 32
    %% Before
    bar [31.8, 0.9]
    %% After
    bar [19.5, 0.1]
```

## Types of changes
### Tests

- more coverage of attribute parsing

### Features

- added basic parser to oxvg_parse
- put lightningcss parsing behind a feature flag
- rewrite path parser to use oxvg_parse parser

### Breaking changes

- path api updated slightly to reduce clones

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [x] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
