### PR TITLE
feat: add format command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ version = "0.0.3"
 dependencies = [
  "bitflags",
  "cfg-if",
+ "clap",
  "cssparser 0.34.0",
  "derive-where",
  "derive_more 2.0.1",

--- a/crates/oxvg/Cargo.toml
+++ b/crates/oxvg/Cargo.toml
@@ -25,6 +25,7 @@ oxvg_ast = { workspace = true, features = [
   "roxmltree",
   "selectors",
   "serialize",
+  "clap",
 ] }
 
 anyhow = { workspace = true }

--- a/crates/oxvg/src/args.rs
+++ b/crates/oxvg/src/args.rs
@@ -1,7 +1,10 @@
 //! Traits and types for handling the command line arguments for OXVG.
 use clap::{Parser, Subcommand};
 
-use crate::{config::Config, optimise::Optimise};
+use crate::{
+    commands::{Format, Optimise},
+    config::Config,
+};
 
 /// A type for a runnable command.
 pub trait RunCommand {
@@ -12,7 +15,7 @@ pub trait RunCommand {
     /// If any part of the lifecycle fails
     /// * Fails to read or parse any files
     /// * Fails to write or serialize to any files
-    fn run(&self, config: Config) -> anyhow::Result<()>;
+    fn run(self, config: Config) -> anyhow::Result<()>;
 }
 
 #[derive(Parser)]
@@ -37,4 +40,9 @@ pub enum Command {
     /// Optimise SVG documents
     #[clap(alias = "optimize")]
     Optimise(Optimise),
+    /// Format SVG documents
+    ///
+    /// This is an alias for `oxvg optimise --extends none` with default options sensible
+    /// for formatting
+    Format(Format),
 }

--- a/crates/oxvg/src/commands.rs
+++ b/crates/oxvg/src/commands.rs
@@ -1,0 +1,6 @@
+//! Various commands that can be executed by oxvg
+mod format;
+mod optimise;
+
+pub use format::Format;
+pub use optimise::Optimise;

--- a/crates/oxvg/src/commands/format.rs
+++ b/crates/oxvg/src/commands/format.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use oxvg_ast::xmlwriter::{Indent, Space};
+use oxvg_optimiser::{Extends, Jobs};
+
+use crate::{args::RunCommand, commands::Optimise, config::Config};
+
+#[derive(clap::Args, Debug)]
+/// Runs [`Optimise`] with options and defaults specialised for formatting
+pub struct Format {
+    /// The target paths to optimise
+    #[clap(value_parser)]
+    pub paths: Vec<PathBuf>,
+    /// Whether to write to the specified file or directory.
+    /// Will use the input if flag is given without a value.
+    /// Defaults to stdout.
+    #[clap(long, short, num_args(0..=1))]
+    pub output: Option<Vec<PathBuf>>,
+    /// If the path is a directory, whether to walk through and optimise it's subdirectories
+    #[clap(long, short, default_value = "false")]
+    pub recursive: bool,
+    /// Search through hidden files and directories
+    #[clap(long, short = '.', default_value = "false")]
+    pub hidden: bool,
+    /// Sets the approximate number of threads to use. A value of 0 (default) will automatically determine the appropriate number
+    #[clap(long, short, default_value = "0")]
+    pub threads: usize,
+    /// When running without a config, sets the default preset to run with
+    #[clap(long, short, default_value = "4")]
+    pub pretty: Indent,
+    /// Controls how the output handles whitespace.
+    #[clap(long, short, default_value = "auto")]
+    pub space: Space,
+}
+
+impl RunCommand for Format {
+    fn run(self, _config: Config) -> anyhow::Result<()> {
+        let optimise = Optimise {
+            paths: self.paths,
+            output: self.output,
+            config: None,
+            recursive: self.recursive,
+            hidden: self.hidden,
+            threads: self.threads,
+            extends: Some(Extends::None),
+            pretty: self.pretty,
+            space: self.space,
+        };
+        optimise.handle_paths(&Jobs::none())
+    }
+}

--- a/crates/oxvg/src/lib.rs
+++ b/crates/oxvg/src/lib.rs
@@ -1,4 +1,4 @@
 //! The OXVG program can be used for vector manipulation.
 pub mod args;
+pub mod commands;
 pub mod config;
-mod optimise;

--- a/crates/oxvg/src/main.rs
+++ b/crates/oxvg/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> anyhow::Result<()> {
 
     match args.command {
         Command::Optimise(args) => args.run(config)?,
+        Command::Format(args) => args.run(config)?,
     }
     Ok(())
 }

--- a/crates/oxvg_ast/Cargo.toml
+++ b/crates/oxvg_ast/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["visitor", "serialize"]
+clap = ["dep:clap"]
 # Includes a parser that uses xml5ever
 markup5ever = [
   "parse",
@@ -45,6 +46,7 @@ oxvg_serialize = { workspace = true, optional = true }
 
 bitflags = { workspace = true, optional = true }
 cfg-if = { workspace = true }
+clap = { workspace = true, optional = true }
 cssparser = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 derive-where = { workspace = true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

This adds a new command to the cli, `oxvg format`, as an alias for `oxvg optimise --extends none --pretty 4 --config ./empty-config.json`

## Motivation and Context

This extends OXVG's usefulness as an SVG toolchain, providing straightforward access to formatting for use in an editor, npm task, ci, etc.

## How Has This Been Tested?

Basic testing against a test svg

## Types of changes

### Features

- Adds clap behind a ff for xmlwriter options
- Adds `--pretty` and `--space` options for optimiser
- Adds `format` command 
- Restructures `oxvg` package slightly

## Checklist:
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [x] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
