### PR TITLE
feat!: improve visitor start method to resemble common usage

### DIFF
--- a/crates/oxvg/src/commands/lint/lsp.rs
+++ b/crates/oxvg/src/commands/lint/lsp.rs
@@ -2,7 +2,7 @@ use oxvg_ast::{
     arena::Allocator,
     node::{Ranges, Ref},
     parse::roxmltree::{parse_with_options, ParsingOptions},
-    visitor::{Info, Visitor},
+    visitor::Visitor,
 };
 use oxvg_lint::error::Error;
 use oxvg_lint::{Rules, Severity};
@@ -72,18 +72,7 @@ impl Backend {
         uri: &Uri,
     ) -> std::result::Result<(), Vec<Diagnostic>> {
         let path = uri.to_file_path().map(|p| p.to_path_buf());
-        let Some(mut root) = dom.find_element() else {
-            return Ok(());
-        };
-        let Err(diagnostics) = self.rules.start(
-            &mut root,
-            &Info {
-                path,
-                multipass_count: 0,
-                allocator,
-            },
-            None,
-        ) else {
+        let Err(diagnostics) = self.rules.start_with_path(dom, allocator, path) else {
             return Ok(());
         };
         Err(diagnostics

--- a/crates/oxvg_lint/src/parse.rs
+++ b/crates/oxvg_lint/src/parse.rs
@@ -4,9 +4,8 @@ use std::{
 };
 
 use oxvg_ast::{
-    element::Element,
     parse::roxmltree::{self, ParsingOptions},
-    visitor::{Info, Visitor},
+    visitor::Visitor,
 };
 
 use crate::{
@@ -123,19 +122,7 @@ impl Rules {
                 ..ParsingOptions::default()
             },
             |root, allocator| {
-                let Some(mut root) = Element::from_parent(root) else {
-                    return Ok(());
-                };
-                let path = path.cloned();
-                let Err(errors) = self.start(
-                    &mut root,
-                    &Info {
-                        path: path.clone(),
-                        multipass_count: 0,
-                        allocator,
-                    },
-                    None,
-                ) else {
+                let Err(errors) = self.start_with_path(root, allocator, path.cloned()) else {
                     return Ok(());
                 };
                 error_count += errors
@@ -150,7 +137,7 @@ impl Rules {
                 let report = Report {
                     source,
                     errors,
-                    path,
+                    path: path.cloned(),
                 };
                 write!(&mut w, "{report}")
             },

--- a/crates/oxvg_lint/src/rules/mod.rs
+++ b/crates/oxvg_lint/src/rules/mod.rs
@@ -55,7 +55,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Rules {
             rules: self,
             reports: RefCell::default(),
         };
-        reporter.start(&mut document.clone(), context.info, None)?;
+        reporter.start_with_context(document, context)?;
         let reports = reporter.reports.take();
         if reports.is_empty() {
             Ok(PrepareOutcome::skip)

--- a/crates/oxvg_optimiser/benches/path.rs
+++ b/crates/oxvg_optimiser/benches/path.rs
@@ -43,7 +43,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                                 let job = ConvertPathData::default();
                                 let info = &Info::new(allocator);
                                 let start = Instant::now();
-                                let _ = black_box(job.start(&mut root, info, None));
+                                let _ = black_box(job.start_with_info(&mut root, info, None));
                                 result += start.elapsed();
                             },
                         )

--- a/crates/oxvg_optimiser/src/jobs/cleanup_enable_background.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_enable_background.rs
@@ -71,7 +71,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupEnableBackground {
             return Ok(PrepareOutcome::skip);
         }
         if let Some(root) = document.find_element() {
-            State::new(&root).start(&mut document.clone(), context.info, None)?;
+            State::new(&root).start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }

--- a/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
@@ -121,11 +121,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupIds {
         }
 
         state.prepare_id_rename(document);
-        state.start(
-            &mut document.clone(),
-            context.info,
-            Some(context.flags.clone()),
-        )?;
+        state.start_with_context(document, context)?;
         Ok(PrepareOutcome::skip) // work done with `state`
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/convert_one_stop_gradients.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_one_stop_gradients.rs
@@ -66,7 +66,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertOneStopGradients {
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
-            State::default().start(&mut document.clone(), context.info, None)?;
+            State::default().start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }

--- a/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
@@ -67,7 +67,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertShapeToPath {
             styles.borrow_mut().0.visit(&mut state)?;
         }
         if !state.referenced_shapes.contains(ReferencedShapes::Path) {
-            state.start(&mut document.clone(), context.info, None)?;
+            state.start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }

--- a/crates/oxvg_optimiser/src/jobs/inline_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/inline_styles.rs
@@ -230,7 +230,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for InlineStyles {
         document: &Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
-        State::new(self).start(&mut document.clone(), context.info, None)?;
+        State::new(self).start_with_context(document, context)?;
         Ok(PrepareOutcome::skip)
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/merge_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_styles.rs
@@ -50,7 +50,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MergeStyles {
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
-            State::default().start(&mut document.clone(), context.info, None)?;
+            State::default().start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }

--- a/crates/oxvg_optimiser/src/jobs/minify_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/minify_styles.rs
@@ -91,7 +91,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MinifyStyles {
         document: &Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
-        State::new(self).start(&mut document.clone(), context.info, None)?;
+        State::new(self).start_with_context(document, context)?;
         Ok(PrepareOutcome::skip)
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -47,13 +47,13 @@ macro_rules! jobs {
             /// Runs each job in the config, returning the number of non-skipped jobs
             fn run_jobs<'input, 'arena>(
                 &self,
-                element: &mut Element<'input, 'arena>,
+                element: &Element<'input, 'arena>,
                 info: &Info<'input, 'arena>
             ) -> Result<usize, JobsError<'input>> {
                 let mut count = 0;
                 $(if let Some(job) = self.$name.as_ref() {
                     log::debug!(concat!("💼 starting ", stringify!($name)));
-                    match job.start(element, info, None) {
+                    match job.start_with_info(element, info, None) {
                         Err(e) if e.is_important() => return Err(e),
                         Err(e) => log::error!("{} failed {e}", stringify!($name)),
                         Ok(r) => if !r.contains(PrepareOutcome::skip) {
@@ -242,12 +242,12 @@ impl Jobs {
         root: Ref<'input, 'arena>,
         info: &Info<'input, 'arena>,
     ) -> Result<(), JobsError<'input>> {
-        let Some(mut root_element) = Element::from_parent(root) else {
+        let Some(root_element) = Element::from_parent(root) else {
             log::warn!("No elements found in the document, skipping");
             return Ok(());
         };
 
-        let count = self.run_jobs(&mut root_element, info)?;
+        let count = self.run_jobs(&root_element, info)?;
         log::debug!("completed {count} jobs");
         Ok(())
     }

--- a/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
@@ -222,13 +222,13 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveHiddenElems {
             opacity_zero: self.opacity_zero.unwrap_or(true),
             ..Data::default()
         };
-        data.start(document, context.info, Some(context.flags.clone()))?;
+        data.start_with_context(document, context)?;
         log::debug!("data collected");
         State {
             options: self,
             data: &mut data,
         }
-        .start(document, context.info, Some(context.flags.clone()))?;
+        .start_with_context(document, context)?;
         Ok(PrepareOutcome::skip)
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
@@ -50,7 +50,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveOffCanvasPaths {
             State {
                 view_box_data: RefCell::new(None),
             }
-            .start(&mut document.clone(), context.info, None)?;
+            .start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }

--- a/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
@@ -48,7 +48,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUnusedNS {
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
-            State::default().start(&mut document.clone(), context.info, None)?;
+            State::default().start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -63,11 +63,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUselessStrokeAndFill {
             options: self,
             id_rc_byte: Cell::new(None),
         }
-        .start(
-            &mut document.clone(),
-            &context.info.clone(),
-            Some(context.flags.clone()),
-        )?;
+        .start_with_context(document, context)?;
         Ok(PrepareOutcome::skip)
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
@@ -64,7 +64,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveXlink {
             overridden_prefix_stack: RefCell::new(vec![]),
             used_in_legacy_element_stack: RefCell::new(vec![]),
         }
-        .start(&mut document.clone(), context.info, None)?;
+        .start_with_context(document, context)?;
         Ok(PrepareOutcome::skip)
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/reuse_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/reuse_paths.rs
@@ -57,7 +57,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ReusePaths {
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
-            State::default().start(&mut document.clone(), context.info, None)?;
+            State::default().start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

Adds/updates starting methods for `Visitor`

## Motivation and Context

Makes the visitor easier to use

## How Has This Been Tested?

- Unit tests

## Types of changes

### Features

- Adds shorthand methods for starting visitor

### Breaking changes

- `Visitor::start` interface is changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
