### PR TITLE
feat: no unknkown elements lint

### DIFF
--- a/crates/oxvg_ast/src/document.rs
+++ b/crates/oxvg_ast/src/document.rs
@@ -63,6 +63,8 @@ impl<'input, 'arena> Document<'input, 'arena> {
             #[cfg(feature = "selectors")]
             selector_flags: std::cell::Cell::new(None),
             #[cfg(feature = "range")]
+            range: None,
+            #[cfg(feature = "range")]
             ranges: std::collections::HashMap::new(),
         }))
         .expect("created element should be an element")

--- a/crates/oxvg_ast/src/element.rs
+++ b/crates/oxvg_ast/src/element.rs
@@ -60,6 +60,8 @@ pub struct ElementData<'a, 'input> {
     name: &'a ElementId<'input>,
     attrs: &'a RefCell<Vec<Attr<'input>>>,
     #[cfg(feature = "range")]
+    range: &'a Option<std::ops::Range<usize>>,
+    #[cfg(feature = "range")]
     ranges: &'a std::collections::HashMap<AttrId<'input>, crate::node::Ranges>,
 }
 
@@ -419,6 +421,8 @@ impl<'input, 'arena> Element<'input, 'arena> {
             #[cfg(feature = "selectors")]
             selector_flags: Cell::new(None),
             #[cfg(feature = "range")]
+            range: None,
+            #[cfg(feature = "range")]
             ranges: std::collections::HashMap::new(),
         });
         self.replace_with(replacement);
@@ -497,6 +501,12 @@ impl<'input, 'arena> Element<'input, 'arena> {
     /// [MDN | attributes](https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes)
     pub fn attributes<'a>(&'a self) -> Attributes<'a, 'input> {
         Attributes(self.data().attrs)
+    }
+
+    #[cfg(feature = "range")]
+    /// Returns the source-code range for the element
+    pub fn range(&self) -> &Option<std::ops::Range<usize>> {
+        self.data().range
     }
 
     #[cfg(feature = "range")]
@@ -731,10 +741,12 @@ impl<'input, 'arena> Element<'input, 'arena> {
         selector_flags.set(Some(flags));
     }
 
-    fn data<'a>(&'a self) -> ElementData<'a, 'input> {
+    pub fn data<'a>(&'a self) -> ElementData<'a, 'input> {
         if let NodeData::Element {
             ref name,
             ref attrs,
+            #[cfg(feature = "range")]
+            ref range,
             #[cfg(feature = "range")]
             ref ranges,
             ..
@@ -743,6 +755,8 @@ impl<'input, 'arena> Element<'input, 'arena> {
             ElementData {
                 name,
                 attrs,
+                #[cfg(feature = "range")]
+                range,
                 #[cfg(feature = "range")]
                 ranges,
             }

--- a/crates/oxvg_ast/src/element.rs
+++ b/crates/oxvg_ast/src/element.rs
@@ -527,7 +527,10 @@ impl<'input, 'arena> Element<'input, 'arena> {
     ///
     /// [MDN | parentElement](https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement)
     pub fn parent_element(&self) -> Option<Self> {
-        self.parent_node()
+        self.parent_node().and_then(|e| match e.node_type() {
+            node::Type::Element => Some(e),
+            _ => None,
+        })
     }
 
     /// Returns the number of child elements of this element.

--- a/crates/oxvg_ast/src/node.rs
+++ b/crates/oxvg_ast/src/node.rs
@@ -90,6 +90,8 @@ pub enum NodeData<'input> {
         /// Flags used for caching whether an element matches a selector
         selector_flags: Cell<Option<selectors::matching::ElementSelectorFlags>>,
         #[cfg(feature = "range")]
+        range: Option<std::ops::Range<usize>>,
+        #[cfg(feature = "range")]
         /// The source-code ranges for each attribute
         ranges: std::collections::HashMap<oxvg_collections::attribute::AttrId<'input>, Ranges>,
     },

--- a/crates/oxvg_ast/src/parse/roxmltree.rs
+++ b/crates/oxvg_ast/src/parse/roxmltree.rs
@@ -215,6 +215,8 @@ fn parse_element<'a, 'input: 'a, 'arena>(
     let xml_node_attributes = xml_node.attributes();
     #[cfg(feature = "range")]
     let mut ranges = HashMap::new();
+    #[cfg(feature = "range")]
+    let range = xml_node.range();
     let mut attrs = Vec::with_capacity(xml_node_attributes.len() + xml_node_namespaces.len());
     attrs.extend(xml_node_namespaces.filter_map(|ns| find_new_xmlns(ns, namespace_map, popped_ns)));
     attrs.extend(xml_node_attributes.map(|attr| {
@@ -239,6 +241,8 @@ fn parse_element<'a, 'input: 'a, 'arena>(
         attrs: RefCell::new(attrs),
         #[cfg(feature = "selectors")]
         selector_flags: std::cell::Cell::new(None),
+        #[cfg(feature = "range")]
+        range: Some(range),
         #[cfg(feature = "range")]
         ranges,
     };

--- a/crates/oxvg_collections/src/element.rs
+++ b/crates/oxvg_collections/src/element.rs
@@ -110,9 +110,14 @@ macro_rules! define_elements {
         impl<'input> ElementId<'input> {
             /// Creates a qualified name from a prefix and local part
             pub fn new(prefix: Prefix<'input>, local: Atom<'input>) -> Self {
-                match (prefix, &*local) {
+                let name = match (prefix.unaliased(), &*local) {
                     $((Prefix::SVG, $name) => Self::$element,)+
-                    (prefix, _) => Self::Unknown(QualName { prefix, local }),
+                    (_, _) => return Self::Unknown(QualName { prefix, local }),
+                };
+                if prefix.is_aliased() {
+                    Self::Aliased { prefix, element_id: Box::new(name) }
+                } else {
+                    name
                 }
             }
 

--- a/crates/oxvg_lint/src/lib.rs
+++ b/crates/oxvg_lint/src/lib.rs
@@ -3,5 +3,6 @@ pub mod error;
 #[cfg(feature = "parse")]
 mod parse;
 mod rules;
+mod utils;
 
 pub use rules::{Rules, Severity};

--- a/crates/oxvg_lint/src/parse.rs
+++ b/crates/oxvg_lint/src/parse.rs
@@ -28,6 +28,14 @@ impl std::fmt::Write for StdoutWriter {
 }
 
 impl Rules {
+    /// Returns a set of rules with all the rules set to [`Severity::Off`]
+    pub fn off() -> Self {
+        Self {
+            no_unknown_elements: Severity::Off,
+            no_unknown_attributes: Severity::Off,
+        }
+    }
+
     /// Analyses the file and reports any problems to standard output
     ///
     /// # Errors

--- a/crates/oxvg_lint/src/rules/no_unknown_attributes.rs
+++ b/crates/oxvg_lint/src/rules/no_unknown_attributes.rs
@@ -8,7 +8,10 @@ use oxvg_collections::{
 };
 use rayon::prelude::*;
 
-use crate::error::{Error, Problem};
+use crate::{
+    error::{Error, Problem},
+    utils::prefix_help,
+};
 
 use super::Severity;
 
@@ -32,20 +35,7 @@ pub fn no_unknown_attributes<'a, 'input>(
         {
             None
         } else {
-            let prefix = attr.prefix();
-            let help = if let Prefix::Unknown { prefix, ns } = prefix {
-                let prefix = prefix.as_deref();
-                let ns = ns.uri();
-                if let Some(prefix) = prefix {
-                    Some(format!(
-                        r#"Unknown prefix defined by `xmlns:{prefix}="{ns}"`"#
-                    ))
-                } else {
-                    Some(format!(r#"Unknown prefix defined by `xmlns="{ns}"`"#))
-                }
-            } else {
-                None
-            };
+            let help = prefix_help(attr.prefix());
             Some(Error {
                 problem: Problem::UnknownAttribute {
                     attribute: attr_id.clone(),

--- a/crates/oxvg_lint/src/rules/no_unknown_elements.rs
+++ b/crates/oxvg_lint/src/rules/no_unknown_elements.rs
@@ -1,0 +1,77 @@
+use oxvg_collections::{element::ElementId, is_prefix};
+
+use crate::{
+    error::{Error, Problem},
+    utils::prefix_help,
+};
+
+use super::Severity;
+
+pub fn no_unknown_elements<'input>(
+    parent: Option<&ElementId<'input>>,
+    name: &ElementId<'input>,
+    range: Option<&std::ops::Range<usize>>,
+    severity: Severity,
+) -> Option<Error<'input>> {
+    let parent = parent?;
+    if !is_prefix!(name.prefix(), SVG) {
+        return None;
+    }
+
+    if parent.is_permitted_child(name) {
+        return None;
+    }
+    Some(Error {
+        problem: Problem::UnknownElement {
+            parent: parent.clone(),
+            element: name.clone(),
+        },
+        severity,
+        // NOTE: roxmltree range spans from the start of the opening-tag to the end of the closing-tag
+        //       Using a zero-len range will cause the error reporter to use `utils::naive_range`.
+        range: range.map(|range| range.start..range.start),
+        help: prefix_help(name.prefix()),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::no_unknown_elements;
+    use crate::{error::Problem, Severity};
+    use oxvg_collections::element::ElementId;
+
+    static PARENT_ELEMENT: Option<ElementId<'static>> = Some(ElementId::Svg);
+    static KNOWN_ELEMENT: ElementId<'static> = ElementId::Circle;
+    static UNKNOWN_ELEMENT: ElementId<'static> = ElementId::Stop;
+
+    #[test]
+    fn report_unknown_element_ok() {
+        let report = no_unknown_elements(
+            PARENT_ELEMENT.as_ref(),
+            &KNOWN_ELEMENT,
+            None,
+            Severity::Error,
+        );
+        assert!(report.is_none());
+    }
+    #[test]
+    fn report_unknown_element() {
+        let report = no_unknown_elements(
+            PARENT_ELEMENT.as_ref(),
+            &UNKNOWN_ELEMENT,
+            Some(&(0..1)),
+            Severity::Error,
+        )
+        .unwrap();
+        assert_eq!(
+            report.problem,
+            Problem::UnknownElement {
+                parent: PARENT_ELEMENT.clone().unwrap(),
+                element: UNKNOWN_ELEMENT.clone(),
+            }
+        );
+        assert_eq!(report.severity, Severity::Error);
+        assert_eq!(report.range, Some(0..0));
+        assert_eq!(report.help, None);
+    }
+}

--- a/crates/oxvg_lint/src/utils.rs
+++ b/crates/oxvg_lint/src/utils.rs
@@ -1,0 +1,36 @@
+use std::ops::Range;
+
+use oxvg_collections::name::Prefix;
+
+pub fn prefix_help(prefix: &Prefix) -> Option<String> {
+    if let Prefix::Unknown { prefix, ns } = prefix {
+        let prefix = prefix.as_deref();
+        let ns = ns.uri();
+        if let Some(prefix) = prefix {
+            Some(format!(
+                r#"Unknown prefix defined by `xmlns:{prefix}="{ns}"`"#
+            ))
+        } else {
+            Some(format!(r#"Unknown prefix defined by `xmlns="{ns}"`"#))
+        }
+    } else {
+        None
+    }
+}
+
+pub fn naive_range(source: &[u8], mut start: usize) -> Range<usize> {
+    while start < source.len() {
+        start += 1;
+        if !(source[start] as char).is_ascii_whitespace() && source[start] != b'<' {
+            break;
+        }
+    }
+    let mut end = start;
+    while end < source.len() {
+        if (source[end] as char).is_ascii_whitespace() || source[end] == b'>' {
+            break;
+        }
+        end += 1;
+    }
+    start..end
+}


### PR DESCRIPTION
## Description

Creates a new lint that detects when an element is unknown to it's parent's content-model.

## Motivation and Context

Helps user's discover when they accidentally break the document's content-model

## How Has This Been Tested?

- Unit tests
- w3c
- lsp in Helix

## Types of changes
### Fixes

- Fixes `Element::parent_element` returning `Some` when parent is a document node
- Fixes aliased elements being parsed as `ElementId::Unknown` instead of `ElementId::Aliased`

### Features

- Adds new lint

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
