### PR TITLE
fix: #184 remove serde from napi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,6 @@ dependencies = [
  "parcel_selectors",
  "paste",
  "pathdiff",
- "serde",
  "smallvec",
 ]
 
@@ -1139,8 +1138,6 @@ dependencies = [
  "napi-sys",
  "nohash-hasher",
  "rustc-hash",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1326,7 +1323,6 @@ dependencies = [
  "oxvg_ast",
  "oxvg_optimiser",
  "roxmltree",
- "serde_json",
  "typed-arena",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ oxvg_ast = { path = "crates/oxvg_ast", version = ">=0.0" }
 oxvg_collections = { path = "crates/oxvg_collections", version = ">=0.0" }
 oxvg_diagnostics = { path = "crates/oxvg_diagnostics", version = ">=0.0" }
 oxvg_lint = { path = "crates/oxvg_lint", version = ">=0.0" }
-oxvg_optimiser = { path = "crates/oxvg_optimiser", version = ">=0.0" }
+oxvg_optimiser = { path = "crates/oxvg_optimiser", default-features = false, version = ">=0.0" }
 oxvg_path = { path = "crates/oxvg_path", version = ">=0.0" }
 oxvg_parse = { path = "crates/oxvg_parse", version = ">=0.0" }
 oxvg_serialize = { path = "crates/oxvg_serialize", version = ">=0.0" }
@@ -52,16 +52,12 @@ itertools = "0.14"
 lazy_static = "1.5"
 lightningcss = { version = "1.0.0-alpha.63", default-features = false, features = [
   "grid",
-  "nodejs",
   "visitor",
 ] }
-log = "0.4"
+log = { version = "0.4", features = ["release_max_level_off"] }
 lsp-types = "0.97"
 markup5ever = "0.14"
-napi = { version = "3.4", default-features = false, features = [
-  "serde-json",
-  "napi7",
-] }
+napi = { version = "3.4", default-features = false, features = ["napi7"] }
 napi-build = { version = "2.2", default-features = false }
 napi-derive = { version = "3.3" }
 paste = "1.0"

--- a/crates/oxvg_optimiser/Cargo.toml
+++ b/crates/oxvg_optimiser/Cargo.toml
@@ -14,10 +14,12 @@ workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = []
+default = ["serde"]
 clap = ["dep:clap"]
+serde = ["dep:serde", "dep:serde_json", "dep:serde_with", "oxvg_path/serde"]
 napi = ["dep:napi", "dep:napi-derive", "oxvg_path/napi"]
 wasm = [
+  "serde",
   "dep:wasm-bindgen",
   "dep:serde-wasm-bindgen",
   "dep:tsify",
@@ -31,7 +33,7 @@ oxvg_ast = { workspace = true, features = [
   "visitor",
 ] }
 oxvg_collections = { workspace = true }
-oxvg_path = { workspace = true, features = ["serde"] }
+oxvg_path = { workspace = true }
 oxvg_serialize = { workspace = true }
 
 anyhow = { workspace = true }
@@ -42,10 +44,10 @@ dashmap = { workspace = true }
 derive_more = { workspace = true }
 derive-where = { workspace = true }
 itertools = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 serde-wasm-bindgen = { workspace = true, optional = true }
-serde_with = { workspace = true }
+serde_with = { workspace = true, optional = true }
 lazy_static = { workspace = true }
 lightningcss = { workspace = true }
 log = { workspace = true }

--- a/crates/oxvg_optimiser/src/jobs/add_attributes_to_s_v_g_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/add_attributes_to_s_v_g_element.rs
@@ -6,6 +6,7 @@ use oxvg_ast::{
     visitor::{Context, Visitor},
 };
 use oxvg_collections::attribute::Attr;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -15,8 +16,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Default, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Adds attributes to SVG elements in the document. This is not an optimisation
 /// and will increase the size of SVG documents.
 ///

--- a/crates/oxvg_optimiser/src/jobs/add_classes_to_s_v_g_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/add_classes_to_s_v_g_element.rs
@@ -12,6 +12,7 @@ use oxvg_collections::{
         list_of::{ListOf, Space},
     },
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -21,8 +22,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Adds to the `class` attribute of the root `<svg>` element, omitting duplicates
 ///
 /// # Differences to SVGO

--- a/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
+++ b/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
@@ -19,6 +19,7 @@ use oxvg_collections::attribute::{
     Attr, AttrId,
 };
 use oxvg_path::{command::Data, convert, Path};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -28,8 +29,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Default, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Apply transformations of a `transform` attribute to the path data, removing the `transform`
 /// in the process.
 ///
@@ -56,7 +58,7 @@ pub struct ApplyTransforms {
     #[cfg_attr(feature = "wasm", tsify(optional))]
     pub transform_precision: Option<f64>,
     /// Whether or not to apply transforms to paths with a stroke.
-    #[serde(default = "bool::default")]
+    #[cfg_attr(feature = "serde", serde(default = "bool::default"))]
     pub apply_transforms_stroked: bool,
 }
 

--- a/crates/oxvg_optimiser/src/jobs/cleanup_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_attrs.rs
@@ -4,6 +4,7 @@ use oxvg_ast::{
     visitor::{Context, Visitor},
 };
 use oxvg_collections::content_type::{ContentType, ContentTypeRef};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -13,8 +14,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes redundant whitespace from attribute values.
 ///
 /// # Correctness
@@ -33,13 +35,13 @@ use crate::error::JobsError;
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct CleanupAttrs {
-    #[serde(default = "newlines_default")]
+    #[cfg_attr(feature = "serde", serde(default = "newlines_default"))]
     /// Whether to replace `'\n'` with `' '`.
     pub newlines: bool,
-    #[serde(default = "trim_default")]
+    #[cfg_attr(feature = "serde", serde(default = "trim_default"))]
     /// Whether to remove whitespace from each end of the value
     pub trim: bool,
-    #[serde(default = "spaces_default")]
+    #[cfg_attr(feature = "serde", serde(default = "spaces_default"))]
     /// Whether to replace multiple whitespace characters with a single `' '`.
     pub spaces: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/cleanup_enable_background.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_enable_background.rs
@@ -22,6 +22,7 @@ use oxvg_collections::{
     content_type::ContentType,
     element::ElementId,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::JobsError;
@@ -31,8 +32,9 @@ use tsify::Tsify;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Cleans up `enable-background` attributes and styles. It will only remove it if
 /// - The document has no `<filter>` element; and
 /// - The value matches the document's width and height; or

--- a/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
@@ -12,6 +12,7 @@ use oxvg_collections::{
     attribute::{core::NonWhitespace, Attr, AttrId},
     content_type::Reference,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::JobsError;
@@ -45,8 +46,9 @@ struct State<'o, 'input, 'arena> {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes unused ids and minifies used ids.
 ///
 /// # Differences to SVGO
@@ -69,10 +71,10 @@ struct State<'o, 'input, 'arena> {
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct CleanupIds {
-    #[serde(default = "default_remove")]
+    #[cfg_attr(feature = "serde", serde(default = "default_remove"))]
     /// Whether to remove unreferenced ids.
     pub remove: bool,
-    #[serde(default = "default_minify")]
+    #[cfg_attr(feature = "serde", serde(default = "default_minify"))]
     /// Whether to minify ids
     pub minify: bool,
     /// Skips ids that match an item in the list
@@ -81,7 +83,7 @@ pub struct CleanupIds {
     /// Skips ids that start with a string matching a prefix in the list
     #[cfg_attr(feature = "wasm", tsify(optional))]
     pub preserve_prefixes: Option<Vec<String>>,
-    #[serde(default = "bool::default")]
+    #[cfg_attr(feature = "serde", serde(default = "bool::default"))]
     /// Whether to run despite `<script>` or `<style>`
     pub force: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
@@ -2,6 +2,7 @@ use oxvg_ast::{
     element::Element,
     visitor::{Context, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -11,8 +12,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Rounds number and removes default `px` unit in attributes specified with number lists.
 ///
 /// # Correctness
@@ -23,18 +25,18 @@ use crate::error::JobsError;
 ///
 /// When a float-precision greater than the maximum is given.
 pub struct CleanupListOfValues {
-    #[serde(default = "default_float_precision")]
+    #[cfg_attr(feature = "serde", serde(default = "default_float_precision"))]
     // WARN: Lightningcss will round values to 5 decimal places
     /// Number of decimal places to round floating point numbers to, to a maximum of 5.
     pub float_precision: u8,
-    #[serde(default = "default_leading_zero")]
+    #[cfg_attr(feature = "serde", serde(default = "default_leading_zero"))]
     #[deprecated(note = "This option has no effect; leading zeroes are always removed")]
     /// Whether to trim leading zeros.
     pub leading_zero: bool,
-    #[serde(default = "default_default_px")]
+    #[cfg_attr(feature = "serde", serde(default = "default_default_px"))]
     /// Whether to remove `px` from a number's unit.
     pub default_px: bool,
-    #[serde(default = "default_convert_to_px")]
+    #[cfg_attr(feature = "serde", serde(default = "default_convert_to_px"))]
     /// Whether to convert absolute units like `cm` and `in` to `px`.
     pub convert_to_px: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
@@ -2,6 +2,7 @@ use oxvg_ast::{
     element::Element,
     visitor::{Context, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -11,8 +12,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Rounds number and removes default `px` unit in attributes specified with a number number.
 ///
 /// # Correctness
@@ -23,18 +25,18 @@ use crate::error::JobsError;
 ///
 /// When a float-precision greater than the maximum is given.
 pub struct CleanupNumericValues {
-    #[serde(default = "default_float_precision")]
+    #[cfg_attr(feature = "serde", serde(default = "default_float_precision"))]
     // WARN: Lightningcss will round values to 5 decimal places
     /// Number of decimal places to round floating point numbers to, to a maximum of 5.
     pub float_precision: u8,
-    #[serde(default = "default_leading_zero")]
+    #[cfg_attr(feature = "serde", serde(default = "default_leading_zero"))]
     #[deprecated(note = "This option has no effect; leading zeroes are always removed")]
     /// Whether to trim leading zeros.
     pub leading_zero: bool,
-    #[serde(default = "default_default_px")]
+    #[cfg_attr(feature = "serde", serde(default = "default_default_px"))]
     /// Whether to remove `px` from a number's unit.
     pub default_px: bool,
-    #[serde(default = "default_convert_to_px")]
+    #[cfg_attr(feature = "serde", serde(default = "default_convert_to_px"))]
     /// Whether to convert absolute units like `cm` and `in` to `px`.
     pub convert_to_px: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
+++ b/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
@@ -12,6 +12,7 @@ use oxvg_collections::{
     content_type::ContentType,
     element::ElementCategory,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -21,8 +22,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Filters `<g>` elements that have no effect.
 ///
 /// For removing empty groups, see [`super::RemoveEmptyContainers`].

--- a/crates/oxvg_optimiser/src/jobs/convert_colors.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_colors.rs
@@ -10,6 +10,7 @@ use oxvg_collections::{
     attribute::{core::Style, Attr},
     element::ElementId,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -19,8 +20,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi)]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// How the type will be converted.
 pub enum Method {
     #[default]
@@ -40,8 +42,9 @@ pub enum Method {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Converts color references to their shortest equivalent.
 ///
 /// Colors are minified using lightningcss' [minification](https://lightningcss.dev/minification.html#minify-colors).

--- a/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
@@ -7,6 +7,7 @@ use oxvg_collections::{
     attribute::{presentation::LengthPercentage, uncategorised::Radius},
     element::ElementId,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::JobsError;
@@ -16,8 +17,9 @@ use tsify::Tsify;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Converts non-eccentric `<ellipse>` to `<circle>` elements.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/convert_one_stop_gradients.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_one_stop_gradients.rs
@@ -26,6 +26,7 @@ use oxvg_collections::{
     content_type::ContentType,
     name::{Prefix, QualName},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -35,8 +36,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Converts `linearGradient` and `radialGradient` nodes that are a solid colour
 /// to the equivalent colour.
 ///

--- a/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
@@ -5,7 +5,9 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_path::{convert, geometry::MakeArcs};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
 use serde_json::Value;
 
 #[cfg(feature = "wasm")]
@@ -15,8 +17,9 @@ use crate::{error::JobsError, utils::style_info::gather_style_info};
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::struct_excessive_bools)]
 /// Converts paths found in `<path>`, `<glyph>`, and `<missing-glyph>` elements. Path
 /// commands are used within the `d` attributes of these elements.
@@ -42,46 +45,46 @@ use crate::{error::JobsError, utils::style_info::gather_style_info};
 /// Rounding errors may result in slight visual differences.
 ///
 pub struct ConvertPathData {
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to remove redundant path commands.
     pub remove_useless: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to round the radius of circular arcs when the effective change is under error bounds.
     pub smart_arc_rounding: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to convert straight curves to lines
     pub straight_curves: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to convert complex curves that look like cubic beziers (q) into them.
     pub convert_to_q: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to convert normal lines that move in one direction to a vertical or horizontal line command.
     pub line_shorthands: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether merge repeated commands into one.
     pub collapse_repeated: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to convert complex curves that look like smooth curves into them.
     pub curve_smooth_shorthands: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to convert lines that close a curve to a close command (z).
     pub convert_to_z: bool,
-    #[serde(default = "bool::default")]
+    #[cfg_attr(feature = "serde", serde(default = "bool::default"))]
     /// Whether to always convert relative paths to absolute, even if larger.
     pub force_absolute_path: bool,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to weakly force absolute commands, when slightly suboptimal
     pub negative_extra_space: bool,
-    #[serde(default = "MakeArcs::default")]
+    #[cfg_attr(feature = "serde", serde(default = "MakeArcs::default"))]
     /// Controls whether to convert from curves to arcs
     pub make_arcs: MakeArcs,
-    #[serde(default = "ConvertPrecision::default")]
+    #[cfg_attr(feature = "serde", serde(default = "ConvertPrecision::default"))]
     #[cfg_attr(feature = "wasm", tsify(type = "null | false | number"))]
     /// Number of decimal places to round to.
     ///
     /// Precisions larger than 20 will be treated as 0.
     pub float_precision: ConvertPrecision,
-    #[serde(default = "flag_default_true")]
+    #[cfg_attr(feature = "serde", serde(default = "flag_default_true"))]
     /// Whether to convert from relative to absolute, when shorter.
     pub utilize_absolute: bool,
 }
@@ -188,11 +191,13 @@ const fn flag_default_true() -> bool {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "serde")]
 enum DeserializePrecisionError {
     OutOfRange,
     InvalidType,
 }
 
+#[cfg(feature = "serde")]
 impl std::fmt::Display for DeserializePrecisionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -202,8 +207,10 @@ impl std::fmt::Display for DeserializePrecisionError {
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde::de::StdError for DeserializePrecisionError {}
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for ConvertPrecision {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -230,6 +237,7 @@ impl<'de> Deserialize<'de> for ConvertPrecision {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for ConvertPrecision {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
@@ -11,6 +11,7 @@ use oxvg_collections::{
     element::ElementId,
 };
 use oxvg_path::{command::Data, convert, Path};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::JobsError;
@@ -22,8 +23,9 @@ use tsify::Tsify;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Converts basic shapes to `<path>` elements
 ///
 /// # Differences to SVGO
@@ -42,12 +44,21 @@ use tsify::Tsify;
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct ConvertShapeToPath {
     /// Whether to convert `<circle>` and `<ellipses>` to paths.
-    #[serde(default = "default_convert_arcs")]
+    #[cfg_attr(feature = "serde", serde(default = "default_convert_arcs"))]
     pub convert_arcs: bool,
     /// The number of decimal places to round to
     #[cfg_attr(feature = "wasm", tsify(type = "null | false | number"))]
-    #[serde(default = "ConvertPrecision::default")]
+    #[cfg_attr(feature = "serde", serde(default = "ConvertPrecision::default"))]
     pub float_precision: ConvertPrecision,
+}
+
+impl Default for ConvertShapeToPath {
+    fn default() -> Self {
+        Self {
+            convert_arcs: default_convert_arcs(),
+            float_precision: ConvertPrecision::default(),
+        }
+    }
 }
 
 impl<'input, 'arena> Visitor<'input, 'arena> for ConvertShapeToPath {

--- a/crates/oxvg_optimiser/src/jobs/convert_style_to_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_style_to_attrs.rs
@@ -7,6 +7,7 @@ use oxvg_ast::{
     visitor::{Context, Visitor},
 };
 use oxvg_collections::attribute::{Attr, AttrId};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -16,8 +17,9 @@ use crate::{error::JobsError, utils::minify_style};
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Converts presentation attributes in element styles to the equivalent XML attribute.
 ///
 /// Presentation attributes can be used in both attributes and styles, but in most cases it'll take fewer
@@ -48,9 +50,17 @@ use crate::{error::JobsError, utils::minify_style};
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct ConvertStyleToAttrs {
-    #[serde(default = "default_keep_important")]
+    #[cfg_attr(feature = "serde", serde(default = "default_keep_important"))]
     /// Whether to always keep `!important` styles.
     pub keep_important: bool,
+}
+
+impl Default for ConvertStyleToAttrs {
+    fn default() -> Self {
+        Self {
+            keep_important: default_keep_important(),
+        }
+    }
 }
 
 impl<'input, 'arena> Visitor<'input, 'arena> for ConvertStyleToAttrs {

--- a/crates/oxvg_optimiser/src/jobs/convert_transform.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_transform.rs
@@ -12,6 +12,7 @@ use oxvg_collections::attribute::{
     transform::{Precision, SVGTransform},
     AttrId,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -21,8 +22,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::struct_excessive_bools)]
 /// Merge transforms and convert to shortest form.
 ///
@@ -37,30 +39,30 @@ use crate::error::JobsError;
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct ConvertTransform {
     /// Whether to convert transforms to their shorthand alternative.
-    #[serde(default = "default_convert_to_shorts")]
+    #[cfg_attr(feature = "serde", serde(default = "default_convert_to_shorts"))]
     pub convert_to_shorts: bool,
     /// Number of decimal places to round degrees to, for `rotate` and `skew`.
     ///
     /// Some of the precision may also be lost during serialization.
-    #[serde(default = "Option::default")]
+    #[cfg_attr(feature = "serde", serde(default = "Option::default"))]
     pub deg_precision: Option<i32>,
     /// Number of decimal places to round to, for `rotate`'s origin and `translate`.
-    #[serde(default = "default_float_precision")]
+    #[cfg_attr(feature = "serde", serde(default = "default_float_precision"))]
     pub float_precision: i32,
     /// Number of decimal places to round to, for `scale`.
-    #[serde(default = "default_transform_precision")]
+    #[cfg_attr(feature = "serde", serde(default = "default_transform_precision"))]
     pub transform_precision: i32,
     /// Whether to convert matrices into transforms.
-    #[serde(default = "default_matrix_to_transform")]
+    #[cfg_attr(feature = "serde", serde(default = "default_matrix_to_transform"))]
     pub matrix_to_transform: bool,
     /// Whether to remove redundant arguments from `translate` (e.g. `translate(10 0)` -> `transflate(10)`).
-    #[serde(default = "default_short_rotate")]
+    #[cfg_attr(feature = "serde", serde(default = "default_short_rotate"))]
     pub short_rotate: bool,
     /// Whether to remove redundant transforms (e.g. `translate(0)`).
-    #[serde(default = "default_remove_useless")]
+    #[cfg_attr(feature = "serde", serde(default = "default_remove_useless"))]
     pub remove_useless: bool,
     /// Whether to merge transforms.
-    #[serde(default = "default_collapse_into_one")]
+    #[cfg_attr(feature = "serde", serde(default = "default_collapse_into_one"))]
     pub collapse_into_one: bool,
 }
 

--- a/crates/oxvg_optimiser/src/jobs/inline_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/inline_styles.rs
@@ -26,6 +26,7 @@ use parcel_selectors::{
     attr::{AttrSelectorOperator, CaseSensitivity},
     parser::LocalName,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -43,8 +44,9 @@ struct RemovedToken<'input, 'arena> {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Merges styles from a `<style>` element to the `style` attribute of matching elements.
 ///
 /// # Differences to SVGO
@@ -62,21 +64,21 @@ struct RemovedToken<'input, 'arena> {
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct InlineStyles {
     /// If to only inline styles if the selector matches one element.
-    #[serde(default = "default_only_matched_once")]
+    #[cfg_attr(feature = "serde", serde(default = "default_only_matched_once"))]
     pub only_matched_once: bool,
     /// If to remove the selector and styles from the stylesheet while inlining the styles. This
     /// does not remove the selectors that did not match any elements.
-    #[serde(default = "default_remove_matched_selectors")]
+    #[cfg_attr(feature = "serde", serde(default = "default_remove_matched_selectors"))]
     pub remove_matched_selectors: bool,
     /// An array of media query conditions to use, such as `screen`. An empty string signifies all
     /// selectors outside of a media query.
     /// Using `["*"]` will match all media-queries
-    #[serde(default = "default_use_mqs")]
+    #[cfg_attr(feature = "serde", serde(default = "default_use_mqs"))]
     pub use_mqs: Vec<String>,
     /// What pseudo-classes and pseudo-elements to use. An empty string signifies all non-pseudo
     /// classes and non-pseudo elements.
     /// Using `["*"]` will match all pseudo-elements and pseudo-classes.
-    #[serde(default = "default_use_pseudos")]
+    #[cfg_attr(feature = "serde", serde(default = "default_use_pseudos"))]
     pub use_pseudos: Vec<String>,
 }
 

--- a/crates/oxvg_optimiser/src/jobs/merge_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_paths.rs
@@ -14,6 +14,7 @@ use oxvg_ast::{
 };
 use oxvg_collections::attribute::{inheritable::Inheritable, path};
 use oxvg_path::command;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -23,8 +24,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Merge multiple paths into one
 ///
 /// # Differences to SVGO
@@ -43,7 +45,7 @@ use crate::error::JobsError;
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct MergePaths {
-    #[serde(default = "default_force")]
+    #[cfg_attr(feature = "serde", serde(default = "default_force"))]
     /// Whether to merge paths despite intersections
     pub force: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/merge_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_styles.rs
@@ -9,6 +9,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::uncategorised::MediaQueryList;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::JobsError;
@@ -26,8 +27,9 @@ struct State<'input, 'arena> {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Merge multiple `<style>` elements into one
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/minify_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/minify_styles.rs
@@ -22,6 +22,7 @@ use oxvg_collections::{
     },
     is_prefix,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{error::JobsError, utils::minify_style};
@@ -47,8 +48,9 @@ pub enum RemoveUnused {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Minify `<style>` elements with lightningcss
 ///
 /// # Differences to SVGO
@@ -67,7 +69,7 @@ pub enum RemoveUnused {
 pub struct MinifyStyles {
     /// Whether to remove styles with no matching elements.
     #[cfg_attr(feature = "wasm", tsify(type = r#"boolean | "force""#, optional))]
-    #[serde(default = "RemoveUnused::default")]
+    #[cfg_attr(feature = "serde", serde(default = "RemoveUnused::default"))]
     pub remove_unused: RemoveUnused,
 }
 
@@ -250,6 +252,7 @@ impl<'a> State<'a, '_, '_> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for RemoveUnused {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -270,6 +273,7 @@ impl<'de> Deserialize<'de> for RemoveUnused {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for RemoveUnused {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -3,7 +3,9 @@ use oxvg_ast::{
     node::Ref,
     visitor::{ContextFlags, Info, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
 use serde_with::skip_serializing_none;
 
 use crate::error::JobsError;
@@ -17,12 +19,13 @@ macro_rules! jobs {
 
         $(pub use self::$name::$job;)+
 
-        #[skip_serializing_none]
+        #[cfg_attr(feature = "serde", skip_serializing_none)]
         #[cfg_attr(feature = "napi", napi(object))]
         #[cfg_attr(feature = "wasm", derive(Tsify))]
         #[cfg_attr(feature = "wasm", tsify(from_wasm_abi, into_wasm_abi))]
-        #[derive(Deserialize, Serialize, Clone, Debug)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+        #[derive(Clone, Debug)]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         /// Each task for optimising an SVG document.
         pub struct Jobs {
             $(
@@ -79,6 +82,7 @@ macro_rules! jobs {
             ///
             /// If you believe an errors should be fixed, please raise an issue
             /// [here](https://github.com/noahbald/oxvg/issues)
+            #[cfg(feature = "serde")]
             pub fn from_svgo_plugin_config(value: Option<Vec<serde_json::Value>>) -> Result<Self, serde_json::Error> {
                 use serde::de::Error as _;
 

--- a/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
@@ -9,6 +9,7 @@ use oxvg_collections::attribute::{
     inheritable::{self, Inheritable},
     Attr, AttrId, AttributeInfo,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -18,8 +19,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Move an element's attributes to it's enclosing group.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
@@ -9,6 +9,7 @@ use oxvg_collections::attribute::{
     inheritable::{self, Inheritable},
     AttrId,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -18,8 +19,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Moves some of a group's attributes to the contained elements.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/precheck.rs
+++ b/crates/oxvg_optimiser/src/jobs/precheck.rs
@@ -6,6 +6,7 @@ See [license](https://github.com/RazrFalcon/svgcleaner/blob/master/LICENSE.txt)
 */
 use oxvg_ast::{element::Element, get_attribute, is_element, visitor::Visitor};
 use oxvg_collections::attribute::AttributeGroup;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -15,8 +16,9 @@ use crate::error::{JobsError, PrecheckError};
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Runs a series of checks to more confidently be sure the document won't break
 /// due to unsupported/unstable features.
 ///
@@ -26,12 +28,21 @@ use crate::error::{JobsError, PrecheckError};
 /// may cause the document to break with optimisations.
 pub struct Precheck {
     /// Whether to exit with an error instead of a log
-    #[serde(default = "default_fail_fast")]
+    #[cfg_attr(feature = "serde", serde(default = "default_fail_fast"))]
     pub fail_fast: bool,
     /// Whether to run thorough pre-clean checks as to maintain document correctness
     /// similar to [svgcleaner](https://github.com/RazrFalcon/svgcleaner)
-    #[serde(default = "default_preclean_check")]
+    #[cfg_attr(feature = "serde", serde(default = "default_preclean_check"))]
     pub preclean_checks: bool,
+}
+
+impl Default for Precheck {
+    fn default() -> Self {
+        Self {
+            fail_fast: default_fail_fast(),
+            preclean_checks: default_preclean_check(),
+        }
+    }
 }
 
 impl<'input, 'arena> Visitor<'input, 'arena> for Precheck {

--- a/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
@@ -10,6 +10,7 @@ use oxvg_ast::{
 };
 use oxvg_collections::content_type::Reference;
 use regex::Match;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -44,8 +45,9 @@ const fn default_prefix_class_names() -> bool {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Prefix element ids and classnames with the filename or provided string. This
 /// is useful for reducing the likelihood of conflicts when inlining SVGs.
 ///
@@ -65,17 +67,17 @@ const fn default_prefix_class_names() -> bool {
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct PrefixIds {
-    #[serde(default = "default_delim")]
+    #[cfg_attr(feature = "serde", serde(default = "default_delim"))]
     /// Content to insert between the prefix and original value.
     pub delim: String,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     /// A string or generator that resolves to a string
     #[cfg_attr(feature = "wasm", tsify(type = "string | boolean | null"))]
     pub prefix: PrefixGenerator,
-    #[serde(default = "default_prefix_ids")]
+    #[cfg_attr(feature = "serde", serde(default = "default_prefix_ids"))]
     /// Whether to prefix ids
     pub prefix_ids: bool,
-    #[serde(default = "default_prefix_class_names")]
+    #[cfg_attr(feature = "serde", serde(default = "default_prefix_class_names"))]
     /// Whether to prefix classnames
     pub prefix_class_names: bool,
 }
@@ -245,6 +247,7 @@ impl PrefixIds {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for PrefixGenerator {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -269,6 +272,7 @@ impl<'de> Deserialize<'de> for PrefixGenerator {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for PrefixGenerator {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
@@ -2,6 +2,7 @@ use oxvg_ast::{
     element::Element,
     visitor::{Context, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -11,8 +12,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// A selector and set of attributes to remove.
 pub struct Selector {
     /// A CSS selector.
@@ -23,8 +25,9 @@ pub struct Selector {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes attributes from elements that match a selector.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
@@ -12,6 +12,7 @@ use oxvg_collections::{
     content_type::{ContentType, ContentTypeRef},
 };
 use oxvg_serialize::{PrinterOptions, ToValue as _};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 fn default_elem_separator() -> String {
@@ -29,8 +30,9 @@ use crate::{error::JobsError, utils::regex_memo};
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Remove attributes based on whether it matches a pattern.
 ///
 /// The patterns syntax is `[ element* : attribute* : value* ]`; where
@@ -65,12 +67,12 @@ pub struct RemoveAttrs {
     // FIXME: We really don't need the complexity of a DSL here.
     /// A list of patterns that match attributes.
     pub attrs: Vec<String>,
-    #[serde(default = "default_elem_separator")]
+    #[cfg_attr(feature = "serde", serde(default = "default_elem_separator"))]
     /// The separator for different parts of the pattern. By default this is `":"`.
     ///
     /// You may need to use this if you need to match attributes with a `:` (i.e. prefixed attributes).
     pub elem_separator: String,
-    #[serde(default = "default_preserve_current_color")]
+    #[cfg_attr(feature = "serde", serde(default = "default_preserve_current_color"))]
     /// Whether to ignore attributes set to `currentColor`
     pub preserve_current_color: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_comments.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_comments.rs
@@ -1,7 +1,9 @@
 use std::sync::LazyLock;
 
 use oxvg_ast::{node::Node, visitor::Visitor};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
 use serde_with::skip_serializing_none;
 
 #[cfg(feature = "wasm")]
@@ -11,9 +13,10 @@ use crate::{error::JobsError, utils::regex_memo};
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", skip_serializing_none)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes XML comments from the document.
 ///
 /// By default this job ignores comments starting with `<!--!` which is often used
@@ -80,6 +83,7 @@ impl RemoveComments {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for PreservePattern {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -90,6 +94,7 @@ impl<'de> Deserialize<'de> for PreservePattern {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for PreservePattern {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
@@ -7,6 +7,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::{AttrId, AttributeInfo};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -77,8 +78,9 @@ impl<'input> AttrStylesheet<'input> {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes deprecated attributes from elements.
 ///
 /// # Correctnesss
@@ -94,7 +96,7 @@ impl<'input> AttrStylesheet<'input> {
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct RemoveDeprecatedAttrs {
-    #[serde(default = "default_remove_unsafe")]
+    #[cfg_attr(feature = "serde", serde(default = "default_remove_unsafe"))]
     /// Whether to remove deprecated presentation attributes
     pub remove_unsafe: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_desc.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_desc.rs
@@ -4,6 +4,7 @@ use oxvg_ast::{
     node::{self},
     visitor::{Context, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -13,8 +14,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes the `<desc>` element from the document when empty or only contains editor attribution.
 ///
 /// # Correctness
@@ -29,7 +31,7 @@ use crate::error::JobsError;
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct RemoveDesc {
-    #[serde(default = "bool::default")]
+    #[cfg_attr(feature = "serde", serde(default = "bool::default"))]
     /// Whether to remove all `<desc>` elements
     pub remove_any: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
@@ -5,6 +5,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::{presentation::LengthPercentage, uncategorised::ViewBox, AttrId};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -14,8 +15,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes `width` and `height` from the `<svg>` and replaces it with `viewBox` if missing.
 ///
 /// This job is the opposite of [`super::RemoveViewBox`] and should be disabled before

--- a/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     node::Node,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes doctype definitions from the document.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_editors_n_s_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_editors_n_s_data.rs
@@ -8,6 +8,7 @@ use oxvg_collections::{
     attribute::{Attr, AttrId},
     name::{Prefix, QualName},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -17,8 +18,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Clone, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes all xml namespaces associated with editing software.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     get_attribute,
     visitor::{Context, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,7 +13,8 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Default, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Default, Debug, Clone)]
 /// Remove elements by ID or classname
 ///
 /// # Correctness
@@ -25,10 +27,10 @@ use crate::error::JobsError;
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct RemoveElementsByAttr {
-    #[serde(default = "Vec::new")]
+    #[cfg_attr(feature = "serde", serde(default = "Vec::new"))]
     /// Ids of elements to be removed
     pub id: Vec<String>,
-    #[serde(default = "Vec::new")]
+    #[cfg_attr(feature = "serde", serde(default = "Vec::new"))]
     /// Class-names of elements to be removed
     pub class: Vec<String>,
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::AttributeGroup;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes empty attributes from elements when safe to do so.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
@@ -5,6 +5,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::element::ElementCategory;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -14,8 +15,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes container elements with no functional children or meaningful attributes.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     has_attribute, is_element,
     visitor::{Context, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes empty `<text>` and `<tspan>` elements. Removes `<tref>` elements that don't
 /// reference anything within the document.
 ///

--- a/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
@@ -21,6 +21,7 @@ use oxvg_collections::{
     },
     element::{ElementId, ElementInfo},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -30,8 +31,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Clone, Default, Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes hidden or invisible elements from the document.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     is_element,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes `<metadata>` from the document.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
@@ -7,6 +7,7 @@ use oxvg_collections::{
     attribute::{AttributeGroup, AttributeInfo},
     content_type::ContentTypeId,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -16,8 +17,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Remove attributes on groups that won't be inherited by it's children.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
@@ -8,6 +8,7 @@ use oxvg_ast::{
 };
 use oxvg_collections::attribute::{path, presentation::LengthPercentage, uncategorised::ViewBox};
 use oxvg_path::{command::Data, Path};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -17,8 +18,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Clone, Default, Debug, Serialize, Deserialize)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// For SVGs with a `viewBox` attribute, removes `<path>` element outside of it's bounds.
 ///
 /// Elements with `transform` are ignored, as they may be affected by animations.

--- a/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     get_attribute, is_element,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes inline JPEGs, PNGs, and GIFs from the document.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
@@ -4,6 +4,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::{Attr, AttributeGroup};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -13,8 +14,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes `<script>` elements, event attributes, and javascript `href`s from the document.
 ///
 /// This can help remove the risk of Cross-site scripting (XSS) attacks.

--- a/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     is_element,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes all `<style>` elements from the document.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_title.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_title.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     is_element,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes the `<title>` element from the document.
 ///
 /// This may affect the accessibility of documents, where the title is used

--- a/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
@@ -15,6 +15,7 @@ use oxvg_collections::{
     is_prefix,
     name::Prefix,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -24,8 +25,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::struct_excessive_bools)]
 /// Removes elements and attributes that are not expected in an SVG document. Removes
 /// attributes that are not expected on a given element. Removes attributes that are
@@ -46,28 +48,31 @@ use crate::error::JobsError;
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct RemoveUnknownsAndDefaults {
-    #[serde(default = "default_unknown_content")]
+    #[cfg_attr(feature = "serde", serde(default = "default_unknown_content"))]
     /// Whether to remove elements that are unknown or unknown for it's parent element.
     pub unknown_content: bool,
-    #[serde(default = "default_unknown_attrs")]
+    #[cfg_attr(feature = "serde", serde(default = "default_unknown_attrs"))]
     /// Whether to remove attributes that are unknown or unknown for it's element.
     pub unknown_attrs: bool,
-    #[serde(default = "default_default_attrs")]
+    #[cfg_attr(feature = "serde", serde(default = "default_default_attrs"))]
     /// Whether to remove attributes that are equivalent to the default for it's element.
     pub default_attrs: bool,
-    #[serde(default = "default_default_markup_declarations")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default = "default_default_markup_declarations")
+    )]
     /// Whether to remove xml declarations equivalent to the default.
     pub default_markup_declarations: bool,
-    #[serde(default = "default_useless_overrides")]
+    #[cfg_attr(feature = "serde", serde(default = "default_useless_overrides"))]
     /// Whether to remove attributes equivalent to it's inherited value.
     pub useless_overrides: bool,
-    #[serde(default = "default_keep_data_attrs")]
+    #[cfg_attr(feature = "serde", serde(default = "default_keep_data_attrs"))]
     /// Whether to keep attributes prefixed with `data-`
     pub keep_data_attrs: bool,
-    #[serde(default = "default_keep_aria_attrs")]
+    #[cfg_attr(feature = "serde", serde(default = "default_keep_aria_attrs"))]
     /// Whether to keep attributes prefixed with `aria-`
     pub keep_aria_attrs: bool,
-    #[serde(default = "default_keep_role_attr")]
+    #[cfg_attr(feature = "serde", serde(default = "default_keep_role_attr"))]
     /// Whether to keep the `role` attribute
     pub keep_role_attr: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
@@ -10,6 +10,7 @@ use oxvg_collections::{
     attribute::{Attr, AttrId},
     name::{Prefix, QualName},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -19,8 +20,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes `xmlns` prefixed elements that are never referenced by a qualified name.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
@@ -4,6 +4,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::element::ElementInfo;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -13,8 +14,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes unreferenced `<defs>` elements
 ///
 /// # Differences to SVGO

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -12,6 +12,7 @@ use oxvg_collections::{
     element::ElementCategory,
     is_prefix,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -21,8 +22,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Removes useless `stroke` and `fill` attributes
 ///
 /// # Correctness
@@ -35,13 +37,13 @@ use crate::error::JobsError;
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct RemoveUselessStrokeAndFill {
-    #[serde(default = "default_stroke")]
+    #[cfg_attr(feature = "serde", serde(default = "default_stroke"))]
     /// Whether to remove redundant strokes
     pub stroke: bool,
-    #[serde(default = "default_fill")]
+    #[cfg_attr(feature = "serde", serde(default = "default_fill"))]
     /// Whether to remove redundant fills
     pub fill: bool,
-    #[serde(default = "default_remove_none")]
+    #[cfg_attr(feature = "serde", serde(default = "default_remove_none"))]
     /// Whether to remove elements with no stroke or fill
     pub remove_none: bool,
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
@@ -7,6 +7,7 @@ use oxvg_ast::{
 use oxvg_collections::{
     atom::Atom, attribute::presentation::LengthPercentage, content_type::ContentType,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -16,8 +17,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes the `viewBox` attribute when it matches the `width` and `height`.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_x_m_l_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_x_m_l_n_s.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     is_element, remove_attribute,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Clone, Default, Debug)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes the `xmlns` attribute from `<svg>`.
 ///
 /// This can be useful for SVGs that will be inlined.

--- a/crates/oxvg_optimiser/src/jobs/remove_x_m_l_proc_inst.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_x_m_l_proc_inst.rs
@@ -3,6 +3,7 @@ use oxvg_ast::{
     node::Node,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -12,8 +13,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Removes the xml declaration from the document.
 ///
 /// # Correctness

--- a/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
@@ -12,6 +12,7 @@ use oxvg_collections::{
     is_prefix,
     name::{QualName, NS},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -21,7 +22,8 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Default)]
 /// Replaces `xlink` prefixed attributes to the native SVG equivalent.
 ///
 /// # Correctness
@@ -34,7 +36,7 @@ use crate::error::JobsError;
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct RemoveXlink {
-    #[serde(default = "bool::default")]
+    #[cfg_attr(feature = "serde", serde(default = "bool::default"))]
     /// Whether to also convert xlink attributes for legacy elements which don't
     /// support the SVG 2 `href` attribute (e.g. `<cursor>`).
     ///

--- a/crates/oxvg_optimiser/src/jobs/reuse_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/reuse_paths.rs
@@ -18,6 +18,7 @@ use oxvg_collections::{
 };
 use oxvg_path::Path;
 use parcel_selectors::parser::Component;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug)]
@@ -34,8 +35,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Default, Clone, Debug, Serialize, Deserialize)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// For duplicate `<path>` elements, replaces it with a `<use>` that references a single
 /// `<path>` definition.
 ///

--- a/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
@@ -2,6 +2,7 @@ use oxvg_ast::{
     element::Element,
     visitor::{Context, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -11,8 +12,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi)]
-#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 /// The method for ordering xmlns attributes
 pub enum XMLNSOrder {
     /// Sort xmlns attributes alphabetically
@@ -29,8 +31,9 @@ pub enum XMLNSOrder {
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// Sorts attributes into a predictable order.
 ///
 /// This doesn't affect the size of a document but will likely improve readability

--- a/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
@@ -5,6 +5,7 @@ use oxvg_ast::{
     is_element,
     visitor::{Context, PrepareOutcome, Visitor},
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "wasm")]
@@ -14,8 +15,9 @@ use crate::error::JobsError;
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "napi", napi(object))]
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 /// Sorts the children of `<defs>` into a predictable order.
 ///
 /// This doesn't affect the size of a document but will likely improve readability

--- a/crates/oxvg_optimiser/src/lib.rs
+++ b/crates/oxvg_optimiser/src/lib.rs
@@ -45,6 +45,7 @@ pub mod error;
 mod jobs;
 mod utils;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 pub use crate::jobs::*;
@@ -56,8 +57,9 @@ use tsify::Tsify;
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "wasm", tsify(from_wasm_abi, into_wasm_abi))]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 /// A preset which the specified jobs can overwrite
 pub enum Extends {
     /// A preset that contains no jobs.

--- a/packages/napi/Cargo.toml
+++ b/packages/napi/Cargo.toml
@@ -23,7 +23,6 @@ oxvg_ast = { workspace = true, features = ["roxmltree", "serialize"] }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 roxmltree = { workspace = true }
-serde_json = { workspace = true }
 typed-arena = { workspace = true }
 
 [build-dependencies]

--- a/packages/napi/index.d.ts
+++ b/packages/napi/index.d.ts
@@ -17,7 +17,7 @@
  * If you believe an errors should be fixed, please raise an issue
  * [here](https://github.com/noahbald/oxvg/issues)
  */
-export declare function convertSvgoConfig(config?: Array<any> | undefined | null): Jobs
+export declare function convertSvgoConfig(config?: Array<'preset-default' | {[K in keyof Jobs]: K | { name: K, params?: Jobs[K] }}[keyof Jobs]> | undefined | null): Jobs
 
 /**
  * Returns the given config with omitted options replaced with the config provided by `extends`.
@@ -83,7 +83,7 @@ export declare function optimise(svg: string, config?: Jobs | undefined | null):
  *
  * Add an attribute with a prefix
  *
- * ```ignore
+ * ```
  * use std::collections::BTreeMap;
  * use oxvg_optimiser::{Jobs, AddAttributesToSVGElement};
  *
@@ -124,13 +124,13 @@ export interface AddAttributesToSvgElement {
  *
  * Use with a list of classes
  *
- * ```ignore
- * use oxvg_optimiser::{Jobs, AddClassesToSVG};
+ * ```
+ * use oxvg_optimiser::{Jobs, AddClassesToSVGElement};
  *
  * let jobs = Jobs {
- *   add_classes_to_svg: Some(AddClassesToSVG {
+ *   add_classes_to_s_v_g_element: Some(AddClassesToSVGElement {
  *     class_names: Some(vec![String::from("foo"), String::from("bar")]),
- *     ..AddClassesToSVG::default()
+ *     ..AddClassesToSVGElement::default()
  *   }),
  *   ..Jobs::none()
  * };
@@ -138,13 +138,13 @@ export interface AddAttributesToSvgElement {
  *
  * Use with a class string
  *
- * ```ignore
- * use oxvg_optimiser::{Jobs, AddClassesToSVG};
+ * ```
+ * use oxvg_optimiser::{Jobs, AddClassesToSVGElement};
  *
  * let jobs = Jobs {
- *   add_classes_to_svg: Some(AddClassesToSVG {
+ *   add_classes_to_s_v_g_element: Some(AddClassesToSVGElement {
  *     class_name: Some(String::from("foo bar")),
- *     ..AddClassesToSVG::default()
+ *     ..AddClassesToSVGElement::default()
  *   }),
  *   ..Jobs::none()
  * };
@@ -475,6 +475,11 @@ export interface ConvertPrecision {
 
 /**
  * Converts basic shapes to `<path>` elements
+ *
+ * # Differences to SVGO
+ *
+ * OXVG will avoid converting shapes which may be referenced by local-name
+ * in stylesheets.
  *
  * # Correctness
  *
@@ -862,7 +867,7 @@ export interface RemoveAttributesBySelector {
  *
  * Match `fill` attribute in `<path>` elements
  *
- * ```ignore
+ * ```
  * use oxvg_optimiser::{Jobs, RemoveAttrs};
  *
  * let mut remove_attrs = RemoveAttrs::default();
@@ -1344,6 +1349,11 @@ export interface RemoveUnusedNs {
 /**
  * Removes unreferenced `<defs>` elements
  *
+ * # Differences to SVGO
+ *
+ * Defs with a class attribute will be retained, as only useful ones should remain
+ * after running `inline_styles`.
+ *
  * # Correctness
  *
  * This job should never visually change the document.
@@ -1430,6 +1440,8 @@ export interface RemoveXlink {
  *
  * This job may break document when used outside of HTML.
  *
+ * This may cause issues if the XMLNS doesn't reference the SVG namespace.
+ *
  * # Errors
  *
  * Never.
@@ -1513,7 +1525,7 @@ export interface SortAttrs {
  *
  * # Correctness
  *
- * This job should never visually change the document.
+ * This job may affect the document if selectors or scripts depend on ordering.
  *
  * # Errors
  *

--- a/packages/napi/src/lib.rs
+++ b/packages/napi/src/lib.rs
@@ -1,5 +1,5 @@
 //! NAPI bindings for OXVG
-use napi::{Error, Status};
+use napi::{bindgen_prelude::Unknown, Error, Status};
 use oxvg_ast::{
   parse::roxmltree::parse,
   serialize::{Node as _, Options},
@@ -87,8 +87,13 @@ pub fn extend(extend: Extends, config: Option<Jobs>) -> Jobs {
 ///
 /// If you believe an errors should be fixed, please raise an issue
 /// [here](https://github.com/noahbald/oxvg/issues)
-pub fn convert_svgo_config(config: Option<Vec<serde_json::Value>>) -> Result<Jobs, Error<Status>> {
-  Jobs::from_svgo_plugin_config(config).map_err(generic_error)
+pub fn convert_svgo_config(
+  #[napi(
+    ts_arg_type = "Array<'preset-default' | {[K in keyof Jobs]: K | { name: K, params?: Jobs[K] }}[keyof Jobs]> | undefined | null"
+  )]
+  config: Option<Vec<Unknown>>,
+) -> Result<Jobs, Error<Status>> {
+  Jobs::napi_from_svgo_plugin_config(config)
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/packages/napi/test.js
+++ b/packages/napi/test.js
@@ -75,6 +75,10 @@ test("optimise with config", async () => {
 					name: "inlineStyles",
 					params: {
 						onlyMatchedOnce: false,
+						// FIXME: Once napi allows optional object values, like `#[serde(default = "...")]`
+						removeMatchedSelectors: true,
+						useMqs: ["", "screen"],
+						usePseudos: [""],
 					},
 				},
 			]);


### PR DESCRIPTION
## Description

Disables serde features from napi dependencies.

Note, `serde` is still a dependency (https://github.com/parcel-bundler/lightningcss/issues/1094), but non-blocking for this PR

## Motivation and Context

Reduces bundle-size and runtime performance of napi

## How Has This Been Tested?

- `pnpm run test`

## Types of changes

### Features

- Disables serde features on dependencies
- Improves typing for SVGO config parser

### Regressions

- Disallows omitted options from SVGO config

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [x] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
