### PR TITLE
feat: lint no deprecated

### DIFF
--- a/crates/oxvg_ast/src/element.rs
+++ b/crates/oxvg_ast/src/element.rs
@@ -744,6 +744,7 @@ impl<'input, 'arena> Element<'input, 'arena> {
         selector_flags.set(Some(flags));
     }
 
+    /// Returns the data points associated with the element
     pub fn data<'a>(&'a self) -> ElementData<'a, 'input> {
         if let NodeData::Element {
             ref name,

--- a/crates/oxvg_ast/src/node.rs
+++ b/crates/oxvg_ast/src/node.rs
@@ -90,6 +90,7 @@ pub enum NodeData<'input> {
         /// Flags used for caching whether an element matches a selector
         selector_flags: Cell<Option<selectors::matching::ElementSelectorFlags>>,
         #[cfg(feature = "range")]
+        /// The source-code range for the element
         range: Option<std::ops::Range<usize>>,
         #[cfg(feature = "range")]
         /// The source-code ranges for each attribute

--- a/crates/oxvg_collections/src/element.rs
+++ b/crates/oxvg_collections/src/element.rs
@@ -982,7 +982,7 @@ define_elements! {
             AttrId::FilterUnits,
             AttrId::PrimitiveUnits,
         ],
-        info: ElementInfo::NonRendering.union(ElementInfo::Legacy),
+        info: ElementInfo::NonRendering,
     },
     Font {
         name: "font",

--- a/crates/oxvg_lint/src/error.rs
+++ b/crates/oxvg_lint/src/error.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
 };
 
-use oxvg_collections::{attribute::AttrId, element::ElementId, name::QualName};
+use oxvg_collections::{attribute::AttrId, element::ElementId};
 
 use crate::{utils::naive_range, Severity};
 
@@ -47,6 +47,8 @@ pub enum Problem<'input> {
         /// The element that's unknown for it's parent's content-model
         element: ElementId<'input>,
     },
+    /// There was an attribute or element that's marked as deprecated and may be removed in the future
+    Deprecated(DeprecatedProblem<'input>),
 }
 impl Display for Problem<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -57,6 +59,29 @@ impl Display for Problem<'_> {
             Self::UnknownElement { parent, element } => f.write_fmt(format_args!(
                 "Unknown element <{element}> for parent <{parent}>"
             )),
+            Self::Deprecated(problem) => problem.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+/// Either an element or an attribute is deprecated
+pub enum DeprecatedProblem<'input> {
+    /// The specified element is deprecated
+    DeprecatedElement(ElementId<'input>),
+    /// The specified attribute is deprecated
+    DeprecatedAttribute(AttrId<'input>),
+}
+impl Display for DeprecatedProblem<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let support = "will be removed in SVG 2 and may not be supported by modern clients.";
+        match self {
+            Self::DeprecatedElement(element) => {
+                f.write_fmt(format_args!("Deprecated element <{element}> {support}"))
+            }
+            Self::DeprecatedAttribute(attribute) => {
+                f.write_fmt(format_args!("Deprecated attribute `{attribute}` {support}"))
+            }
         }
     }
 }

--- a/crates/oxvg_lint/src/parse.rs
+++ b/crates/oxvg_lint/src/parse.rs
@@ -33,6 +33,7 @@ impl Rules {
         Self {
             no_unknown_elements: Severity::Off,
             no_unknown_attributes: Severity::Off,
+            no_deprecated: Severity::Off,
         }
     }
 

--- a/crates/oxvg_lint/src/rules/mod.rs
+++ b/crates/oxvg_lint/src/rules/mod.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 
+mod no_deprecated;
 mod no_unknown_attributes;
 mod no_unknown_elements;
 
@@ -39,6 +40,8 @@ pub struct Rules {
     pub no_unknown_elements: Severity,
     /// Disallow using attributes that do not belong to a known element's content model
     pub no_unknown_attributes: Severity,
+    /// Disallow using deprecated elements and attributes
+    pub no_deprecated: Severity,
 }
 
 struct Reporter<'o, 'input> {
@@ -110,6 +113,18 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Reporter<'_, 'input> {
                 ) {
                     reports.par_extend(r);
                 }
+            }
+        }
+        match &self.rules.no_deprecated {
+            Severity::Off => {}
+            severity => {
+                reports.par_extend(no_deprecated::no_deprecated(
+                    name,
+                    &attributes_slice,
+                    range.as_ref(),
+                    attribute_ranges,
+                    *severity,
+                ));
             }
         }
 

--- a/crates/oxvg_lint/src/rules/no_deprecated.rs
+++ b/crates/oxvg_lint/src/rules/no_deprecated.rs
@@ -1,0 +1,179 @@
+use std::collections::HashMap;
+
+use oxvg_ast::node::Ranges;
+use oxvg_collections::{
+    attribute::{Attr, AttrId, AttributeInfo},
+    element::{ElementId, ElementInfo},
+};
+use rayon::prelude::*;
+
+use crate::error::{DeprecatedProblem, Error, Problem};
+
+use super::Severity;
+
+pub fn no_deprecated<'a, 'input>(
+    element: &'a ElementId<'input>,
+    attributes: &'a [Attr<'input>],
+    range: Option<&'a std::ops::Range<usize>>,
+    attribute_ranges: &'a HashMap<AttrId<'input>, Ranges>,
+    severity: Severity,
+) -> impl ParallelIterator<Item = Error<'input>> + use<'a, 'input> {
+    let once = if element.info().intersects(ElementInfo::Legacy) {
+        rayon::iter::once(Some(Error {
+            problem: Problem::Deprecated(DeprecatedProblem::DeprecatedElement(element.clone())),
+            severity,
+            range: range.map(|range| range.start..range.start),
+            help: None,
+        }))
+    } else {
+        rayon::iter::once(None)
+    }
+    .filter_map(|e| e);
+
+    once.chain(attributes.par_iter().filter_map(move |attr| {
+        let attr_id = attr.name();
+        if !attr_id
+            .info()
+            .intersects(AttributeInfo::DeprecatedSafe.union(AttributeInfo::DeprecatedUnsafe))
+        {
+            return None;
+        }
+        Some(Error {
+            problem: Problem::Deprecated(DeprecatedProblem::DeprecatedAttribute(attr_id.clone())),
+            severity,
+            range: attribute_ranges
+                .get(attr_id)
+                .map(|range| range.name.clone()),
+            help: if attr_id.info().intersects(AttributeInfo::DeprecatedSafe) {
+                Some(String::from("This attribute can be safely removed"))
+            } else {
+                None
+            },
+        })
+    }))
+}
+
+#[cfg(test)]
+mod test {
+    use super::no_deprecated;
+    use crate::{
+        error::{DeprecatedProblem, Problem},
+        Severity,
+    };
+    use oxvg_ast::node::Ranges;
+    use oxvg_collections::{
+        atom::Atom,
+        attribute::{uncategorised::ViewBox, xml::XmlSpace, Attr, AttrId},
+        element::ElementId,
+    };
+    use rayon::iter::ParallelIterator as _;
+    use std::collections::HashMap;
+
+    static OK_ELEMENT: ElementId = ElementId::Svg;
+    static LEGACY_ELEMENT: ElementId = ElementId::TRef;
+    static OK_ATTRIBUTE: Attr = Attr::ViewBox(ViewBox {
+        min_x: 0.0,
+        min_y: 0.0,
+        width: 0.0,
+        height: 0.0,
+    });
+    static DEPRECATED_SAFE_ATTRIBUTE: Attr = Attr::Version(Atom::Static("1.1"));
+    static DEPRECATED_UNSAFE_ATTRIBUTE: Attr = Attr::XmlSpace(XmlSpace::Default);
+    static DEPRECATED_SAFE_ATTR_ID: AttrId = AttrId::Version;
+    static DEPRECATED_UNSAFE_ATTR_ID: AttrId = AttrId::XmlSpace;
+
+    #[test]
+    fn report_deprecated_ok() {
+        let ranges = HashMap::new();
+        let report: Vec<_> = no_deprecated(
+            &OK_ELEMENT,
+            &[OK_ATTRIBUTE.clone()],
+            None,
+            &ranges,
+            Severity::Error,
+        )
+        .collect();
+        assert!(report.is_empty());
+    }
+    #[test]
+    fn report_deprecated_element() {
+        let ranges = HashMap::new();
+        let report: Vec<_> = no_deprecated(
+            &LEGACY_ELEMENT,
+            &[],
+            Some(&(0..1)),
+            &ranges,
+            Severity::Error,
+        )
+        .collect();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].problem,
+            Problem::Deprecated(DeprecatedProblem::DeprecatedElement(LEGACY_ELEMENT.clone()))
+        );
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(0..0));
+        assert_eq!(report[0].help, None);
+    }
+    #[test]
+    fn report_deprecated_attribute_safe() {
+        let ranges = HashMap::from([(
+            DEPRECATED_SAFE_ATTR_ID.clone(),
+            Ranges {
+                range: 0..1,
+                name: 1..2,
+                value: 2..3,
+            },
+        )]);
+        let report: Vec<_> = no_deprecated(
+            &OK_ELEMENT,
+            &[DEPRECATED_SAFE_ATTRIBUTE.clone()],
+            None,
+            &ranges,
+            Severity::Error,
+        )
+        .collect();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].problem,
+            Problem::Deprecated(DeprecatedProblem::DeprecatedAttribute(
+                DEPRECATED_SAFE_ATTR_ID.clone()
+            ))
+        );
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(1..2));
+        assert_eq!(
+            report[0].help,
+            Some(String::from("This attribute can be safely removed"))
+        );
+    }
+    #[test]
+    fn report_deprecated_attribute_unsafe() {
+        let ranges = HashMap::from([(
+            DEPRECATED_UNSAFE_ATTR_ID.clone(),
+            Ranges {
+                range: 0..1,
+                name: 1..2,
+                value: 2..3,
+            },
+        )]);
+        let report: Vec<_> = no_deprecated(
+            &OK_ELEMENT,
+            &[DEPRECATED_UNSAFE_ATTRIBUTE.clone()],
+            None,
+            &ranges,
+            Severity::Error,
+        )
+        .collect();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].problem,
+            Problem::Deprecated(DeprecatedProblem::DeprecatedAttribute(
+                DEPRECATED_UNSAFE_ATTR_ID.clone()
+            ))
+        );
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(1..2));
+        assert_eq!(report[0].help, None);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

Creates a new lint that detects when an element or attribute is deprecated

## Motivation and Context

Helps users discover where their documents are not forward compatible

## How Has This Been Tested?

- unit tests
- w3c

## Types of changes
### Fixes

- Fixes `<filter>` being marked as legacy

### Features

- Adds new lint

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
