### PR TITLE
feat: create lint no_default_attributes

### DIFF
--- a/crates/oxvg_lint/src/error.rs
+++ b/crates/oxvg_lint/src/error.rs
@@ -49,6 +49,8 @@ pub enum Problem<'input> {
     },
     /// There was an attribute or element that's marked as deprecated and may be removed in the future
     Deprecated(DeprecatedProblem<'input>),
+    /// There was an attribute with a value that matches its default
+    DefaultAttribute(AttrId<'input>),
 }
 impl Display for Problem<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -60,6 +62,7 @@ impl Display for Problem<'_> {
                 "Unknown element <{element}> for parent <{parent}>"
             )),
             Self::Deprecated(problem) => problem.fmt(f),
+            Self::DefaultAttribute(attribute) => f.write_fmt(format_args!("The attribute `{attribute}` has a value that matches its default and can be safely omitted"))
         }
     }
 }

--- a/crates/oxvg_lint/src/parse.rs
+++ b/crates/oxvg_lint/src/parse.rs
@@ -34,6 +34,17 @@ impl Rules {
             no_unknown_elements: Severity::Off,
             no_unknown_attributes: Severity::Off,
             no_deprecated: Severity::Off,
+            no_default_attributes: Severity::Off,
+        }
+    }
+
+    /// Returns a balanced set of rules
+    pub fn recommended() -> Self {
+        Self {
+            no_unknown_elements: Severity::Error,
+            no_unknown_attributes: Severity::Error,
+            no_deprecated: Severity::Error,
+            no_default_attributes: Severity::Warn,
         }
     }
 

--- a/crates/oxvg_lint/src/rules/no_default_attributes.rs
+++ b/crates/oxvg_lint/src/rules/no_default_attributes.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+
+use oxvg_ast::node::Ranges;
+use oxvg_collections::attribute::{Attr, AttrId};
+use rayon::prelude::*;
+
+use crate::error::{Error, Problem};
+
+use super::Severity;
+
+pub fn no_default_attributes<'a, 'input>(
+    attributes: &'a [Attr<'input>],
+    attribute_ranges: &'a HashMap<AttrId<'input>, Ranges>,
+    severity: Severity,
+) -> impl ParallelIterator<Item = Error<'input>> + use<'a, 'input> {
+    attributes.par_iter().filter_map(move |attr| {
+        let name = attr.name().clone();
+        if Some(attr) == name.default().as_ref() {
+            Some(Error {
+                range: attribute_ranges.get(&name).map(|range| range.value.clone()),
+                problem: Problem::DefaultAttribute(name),
+                severity,
+                help: None,
+            })
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::no_default_attributes;
+    use crate::{error::Problem, Severity};
+    use oxvg_ast::node::Ranges;
+    use oxvg_collections::attribute::{uncategorised::Target, Attr, AttrId};
+    use rayon::iter::ParallelIterator as _;
+    use std::collections::HashMap;
+
+    static ATTR_NOT_DEFAULT: Attr = Attr::Target(Target::_Blank);
+    static ATTR_DEFAULT: Attr = Attr::Target(Target::_Self);
+    static ATTR_ID: AttrId = AttrId::Target;
+
+    #[test]
+    fn report_no_default_attributes_ok() {
+        let report: Vec<_> = no_default_attributes(
+            &[ATTR_NOT_DEFAULT.clone()],
+            &HashMap::new(),
+            Severity::Error,
+        )
+        .collect();
+        assert!(report.is_empty());
+    }
+
+    #[test]
+    fn report_no_default_attributes_error() {
+        let report: Vec<_> = no_default_attributes(
+            &[ATTR_DEFAULT.clone()],
+            &HashMap::from([(
+                ATTR_ID.clone(),
+                Ranges {
+                    range: 0..1,
+                    name: 1..2,
+                    value: 2..3,
+                },
+            )]),
+            Severity::Error,
+        )
+        .collect();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].problem,
+            Problem::DefaultAttribute(ATTR_ID.clone())
+        );
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(2..3));
+        assert_eq!(report[0].help, None);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

Creates a new lint that detects when an attribute's value matches its default

## Motivation and Context

Helps users discover where they can omit redundant attributes

## How Has This Been Tested?

- Unit tests
- w3c

## Types of changes
### Fixes

- Fixes being unable to omit lints in oxvg config

### Features

- Adds new lint
- Adds recommended preset

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
