### PR TITLE
feat: lint no xlink

### DIFF
--- a/crates/oxvg/src/commands/lint.rs
+++ b/crates/oxvg/src/commands/lint.rs
@@ -30,7 +30,7 @@ pub struct Check {
 }
 impl RunCommand for Check {
     async fn run(self, config: Config) -> anyhow::Result<()> {
-        self.walk(&config.lint.unwrap_or_default())
+        self.walk(&config.lint.unwrap_or_else(Rules::recommended))
     }
 }
 impl Check {
@@ -64,7 +64,8 @@ pub struct Serve {
 }
 impl RunCommand for Serve {
     async fn run(self, config: Config) -> anyhow::Result<()> {
-        Ok(lsp::serve(config.lint.unwrap_or_default()).await)
+        lsp::serve(config.lint.unwrap_or_else(Rules::recommended)).await;
+        Ok(())
     }
 }
 

--- a/crates/oxvg_lint/src/parse.rs
+++ b/crates/oxvg_lint/src/parse.rs
@@ -35,6 +35,7 @@ impl Rules {
             no_unknown_attributes: Severity::Off,
             no_deprecated: Severity::Off,
             no_default_attributes: Severity::Off,
+            no_x_link: Severity::Off,
         }
     }
 
@@ -45,6 +46,7 @@ impl Rules {
             no_unknown_attributes: Severity::Error,
             no_deprecated: Severity::Error,
             no_default_attributes: Severity::Warn,
+            no_x_link: Severity::Warn,
         }
     }
 

--- a/crates/oxvg_lint/src/rules/mod.rs
+++ b/crates/oxvg_lint/src/rules/mod.rs
@@ -14,6 +14,7 @@ mod no_default_attributes;
 mod no_deprecated;
 mod no_unknown_attributes;
 mod no_unknown_elements;
+mod no_xlink;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -49,6 +50,9 @@ pub struct Rules {
     #[cfg_attr(feature = "serde", serde(default = "Severity::off"))]
     /// Disallow using attribute values that can be omitted
     pub no_default_attributes: Severity,
+    #[cfg_attr(feature = "serde", serde(default = "Severity::off"))]
+    /// Disallow using xlink attributes
+    pub no_x_link: Severity,
 }
 
 struct Reporter<'o, 'input> {
@@ -143,6 +147,14 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Reporter<'_, 'input> {
                     *severity,
                 ));
             }
+        }
+        match &self.rules.no_x_link {
+            Severity::Off => {}
+            severity => reports.par_extend(no_xlink::no_xlink(
+                &attributes_slice,
+                attribute_ranges,
+                *severity,
+            )),
         }
 
         Ok(())

--- a/crates/oxvg_lint/src/rules/no_xlink.rs
+++ b/crates/oxvg_lint/src/rules/no_xlink.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+
+use oxvg_ast::node::Ranges;
+use oxvg_collections::{
+    attribute::{xlink::XLinkShow, Attr, AttrId},
+    is_prefix,
+};
+use rayon::prelude::*;
+
+use crate::error::{Error, NoXLinkProblem, Problem};
+
+use super::Severity;
+
+pub fn no_xlink<'a, 'input>(
+    attributes: &'a [Attr<'input>],
+    attribute_ranges: &'a HashMap<AttrId<'input>, Ranges>,
+    severity: Severity,
+) -> impl ParallelIterator<Item = Error<'input>> + use<'a, 'input> {
+    attributes.par_iter().filter_map(move |attr| {
+        let attr_id = attr.name();
+        let problem = match attr.unaliased() {
+            Attr::XLinkShow(XLinkShow::Replace) => {
+                Problem::NoXLink(NoXLinkProblem::XLinkShowReplace)
+            }
+            Attr::XLinkShow(XLinkShow::New) => Problem::NoXLink(NoXLinkProblem::XLinkShowNew),
+            Attr::XLinkTitle(_) => Problem::NoXLink(NoXLinkProblem::XLinkTitle),
+            Attr::XLinkHref(_) => Problem::NoXLink(NoXLinkProblem::XLinkHref),
+            _ => {
+                if is_prefix!(attr_id, XLink) {
+                    Problem::NoXLink(NoXLinkProblem::XLinkUnsupported(attr_id.clone()))
+                } else {
+                    return None;
+                }
+            }
+        };
+        Some(Error {
+            problem,
+            severity,
+            range: attribute_ranges
+                .get(attr_id)
+                .map(|range| range.range.clone()),
+            help: None,
+        })
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::no_xlink;
+    use crate::{
+        error::{NoXLinkProblem, Problem},
+        Severity,
+    };
+    use oxvg_ast::node::Ranges;
+    use oxvg_collections::{
+        atom::Atom,
+        attribute::{Attr, AttrId},
+        name::{Prefix, QualName},
+    };
+    use rayon::iter::ParallelIterator as _;
+    use std::collections::HashMap;
+
+    static SVG_ATTR: Attr = Attr::Href(Atom::Static("#"));
+    static XLINK_ATTR: Attr = Attr::XLinkHref(Atom::Static("#"));
+    static UNKNOWN_XLINK_ATTR: Attr = Attr::Unparsed {
+        attr_id: AttrId::Unknown(QualName {
+            prefix: Prefix::XLink,
+            local: Atom::Static("foo"),
+        }),
+        value: Atom::Static("bar"),
+    };
+    static XLINK_ATTR_ID: AttrId = AttrId::XLinkHref;
+    static UNKNOWN_XLINK_ATTR_ID: AttrId = AttrId::Unknown(QualName {
+        prefix: Prefix::XLink,
+        local: Atom::Static("foo"),
+    });
+
+    #[test]
+    fn report_no_xlink_ok() {
+        let attrs = [SVG_ATTR.clone()];
+        let ranges = HashMap::new();
+        let report: Vec<_> = no_xlink(&attrs, &ranges, Severity::Error).collect();
+        assert_eq!(report.len(), 0);
+    }
+
+    #[test]
+    fn report_no_xlink_known() {
+        let attrs = [XLINK_ATTR.clone()];
+        let ranges = HashMap::from([(
+            XLINK_ATTR_ID.clone(),
+            Ranges {
+                range: 0..1,
+                name: 1..2,
+                value: 2..3,
+            },
+        )]);
+        let report: Vec<_> = no_xlink(&attrs, &ranges, Severity::Error).collect();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].problem,
+            Problem::NoXLink(NoXLinkProblem::XLinkHref)
+        );
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(0..1));
+        assert_eq!(report[0].help, None);
+    }
+
+    #[test]
+    fn report_no_xlink_unknown() {
+        let attrs = [UNKNOWN_XLINK_ATTR.clone()];
+        let ranges = HashMap::from([(
+            UNKNOWN_XLINK_ATTR_ID.clone(),
+            Ranges {
+                range: 0..1,
+                name: 1..2,
+                value: 2..3,
+            },
+        )]);
+        let report: Vec<_> = no_xlink(&attrs, &ranges, Severity::Error).collect();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].problem,
+            Problem::NoXLink(NoXLinkProblem::XLinkUnsupported(
+                UNKNOWN_XLINK_ATTR_ID.clone()
+            ))
+        );
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(0..1));
+        assert_eq!(report[0].help, None);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

Creates a new lint that detects when xlink attributes are used

## Motivation and Context

Helps users discover xlink attributes that may not have wide client support

## How Has This Been Tested?

- w3c
- Unit tests

## Types of changes

### Features

- Adds new lint
- Updates cli lint defaults to recommended

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
