### PR TITLE
feat: clean lint no_unused_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ dependencies = [
  "bytecount",
  "clap",
  "insta",
+ "lightningcss",
  "lsp-types",
  "oxvg_ast",
  "oxvg_collections",

--- a/crates/oxvg_lint/Cargo.toml
+++ b/crates/oxvg_lint/Cargo.toml
@@ -23,6 +23,7 @@ oxvg_collections = { workspace = true }
 bytecount = { workspace = true }
 clap = { workspace = true, optional = true }
 lsp-types = { workspace = true, optional = true }
+lightningcss = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, optional = true }
 

--- a/crates/oxvg_lint/src/error.rs
+++ b/crates/oxvg_lint/src/error.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
 };
 
-use oxvg_collections::{attribute::AttrId, element::ElementId};
+use oxvg_collections::{atom::Atom, attribute::AttrId, element::ElementId};
 
 use crate::{utils::naive_range, Severity};
 
@@ -53,6 +53,7 @@ pub enum Problem<'input> {
     DefaultAttribute(AttrId<'input>),
     /// There was an `xlink`-prefixed attribute used in the document.
     NoXLink(NoXLinkProblem<'input>),
+    UnreferencedId(Atom<'input>),
 }
 impl Display for Problem<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -65,7 +66,8 @@ impl Display for Problem<'_> {
             )),
             Self::Deprecated(problem) => problem.fmt(f),
             Self::DefaultAttribute(attribute) => f.write_fmt(format_args!("The attribute `{attribute}` has a value that matches its default and can be safely omitted")),
-            Self::NoXLink(problem) => problem.fmt(f)
+            Self::NoXLink(problem) => problem.fmt(f),
+            Self::UnreferencedId(id) => f.write_fmt(format_args!(r#"The id `"{id}"` is not referenced anywhere else in the document"#)),
         }
     }
 }

--- a/crates/oxvg_lint/src/parse.rs
+++ b/crates/oxvg_lint/src/parse.rs
@@ -36,6 +36,7 @@ impl Rules {
             no_deprecated: Severity::Off,
             no_default_attributes: Severity::Off,
             no_x_link: Severity::Off,
+            no_unused_ids: Severity::Off,
         }
     }
 
@@ -47,6 +48,7 @@ impl Rules {
             no_deprecated: Severity::Error,
             no_default_attributes: Severity::Warn,
             no_x_link: Severity::Warn,
+            no_unused_ids: Severity::Warn,
         }
     }
 

--- a/crates/oxvg_lint/src/rules/mod.rs
+++ b/crates/oxvg_lint/src/rules/mod.rs
@@ -1,8 +1,18 @@
-use std::{cell::RefCell, fmt::Write};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    fmt::Write,
+};
 
+use lightningcss::visitor::Visit as _;
 use oxvg_ast::{
     element::Element,
-    visitor::{Context, PrepareOutcome, Visitor},
+    node::Ranges,
+    visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
+};
+use oxvg_collections::{
+    atom::Atom,
+    attribute::{Attr, AttrId},
 };
 use rayon::prelude::*;
 #[cfg(feature = "serde")]
@@ -14,6 +24,7 @@ mod no_default_attributes;
 mod no_deprecated;
 mod no_unknown_attributes;
 mod no_unknown_elements;
+mod no_unused_ids;
 mod no_xlink;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -53,11 +64,16 @@ pub struct Rules {
     #[cfg_attr(feature = "serde", serde(default = "Severity::off"))]
     /// Disallow using xlink attributes
     pub no_x_link: Severity,
+    #[cfg_attr(feature = "serde", serde(default = "Severity::off"))]
+    /// Disallow using id values that are not referenced by the document
+    pub no_unused_ids: Severity,
 }
 
 struct Reporter<'o, 'input> {
     rules: &'o Rules,
     reports: RefCell<Vec<Error<'input>>>,
+    ids: RefCell<HashMap<Atom<'input>, Option<Ranges>>>,
+    referenced_ids: RefCell<HashSet<String>>,
 }
 
 impl<'input, 'arena> Visitor<'input, 'arena> for Rules {
@@ -68,10 +84,18 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Rules {
         document: &Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
-        let reporter = Reporter {
+        context.query_has_script(document);
+        context.query_has_stylesheet(document);
+
+        let mut reporter = Reporter {
             rules: self,
             reports: RefCell::default(),
+            ids: RefCell::default(),
+            referenced_ids: RefCell::default(),
         };
+        for style_sheet in &context.query_has_stylesheet_result {
+            style_sheet.borrow_mut().visit(&mut reporter).ok();
+        }
         reporter.start_with_context(document, context)?;
         let reports = reporter.reports.take();
         if reports.is_empty() {
@@ -157,6 +181,68 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Reporter<'_, 'input> {
             )),
         }
 
+        drop(attributes_slice);
+        let mut referenced_ids = self.referenced_ids.borrow_mut();
+        for mut attribute in attributes.into_iter_mut() {
+            if let Attr::Id(id) = attribute.unaliased() {
+                self.ids
+                    .borrow_mut()
+                    .insert(id.0.clone(), attribute_ranges.get(&AttrId::Id).cloned());
+                continue;
+            }
+            attribute.value_mut().visit_id(|id| {
+                referenced_ids.insert(id.to_string());
+            });
+            attribute.value_mut().visit_url(|url| {
+                if let Some(url) = url.strip_prefix('#') {
+                    referenced_ids.insert(url.to_string());
+                }
+            });
+        }
+
+        Ok(())
+    }
+
+    fn exit_document(
+        &self,
+        _document: &Element<'input, 'arena>,
+        context: &Context<'input, 'arena, '_>,
+    ) -> Result<(), Self::Error> {
+        if context
+            .flags
+            .intersects(ContextFlags::query_has_script_result)
+        {
+            return Ok(());
+        }
+
+        let referenced_ids = self.referenced_ids.borrow();
+        let ids = self.ids.borrow();
+        let mut reports = self.reports.borrow_mut();
+
+        match self.rules.no_unused_ids {
+            Severity::Off => {}
+            severity => reports.par_extend(no_unused_ids::no_unused_ids(
+                &ids,
+                &referenced_ids,
+                severity,
+            )),
+        }
+        Ok(())
+    }
+}
+impl<'i> lightningcss::visitor::Visitor<'i> for Reporter<'_, '_> {
+    type Error = ();
+
+    fn visit_types(&self) -> lightningcss::visitor::VisitTypes {
+        lightningcss::visit_types!(URLS)
+    }
+    fn visit_url(
+        &mut self,
+        url: &mut lightningcss::values::url::Url<'i>,
+    ) -> Result<(), Self::Error> {
+        if let Some(id) = url.url.strip_prefix('#') {
+            self.referenced_ids.borrow_mut().insert(id.to_string());
+        }
         Ok(())
     }
 }

--- a/crates/oxvg_lint/src/rules/no_unused_ids.rs
+++ b/crates/oxvg_lint/src/rules/no_unused_ids.rs
@@ -1,0 +1,75 @@
+use std::collections::{HashMap, HashSet};
+
+use oxvg_ast::node::Ranges;
+use oxvg_collections::atom::Atom;
+use rayon::prelude::*;
+
+use crate::error::{Error, Problem};
+
+use super::Severity;
+
+pub fn no_unused_ids<'a, 'input>(
+    ids: &'a HashMap<Atom<'input>, Option<Ranges>>,
+    referenced_ids: &'a HashSet<String>,
+    severity: Severity,
+) -> impl ParallelIterator<Item = Error<'input>> + use<'a, 'input> {
+    ids.par_iter().filter_map(move |(id, ranges)| {
+        if referenced_ids.contains(id.as_str()) {
+            None
+        } else {
+            Some(Error {
+                problem: Problem::UnreferencedId(id.clone()),
+                severity,
+                range: ranges.as_ref().map(|ranges| ranges.value.clone()),
+                help: None,
+            })
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::no_unused_ids;
+    use crate::{error::Problem, Severity};
+    use oxvg_ast::node::Ranges;
+    use oxvg_collections::atom::Atom;
+    use rayon::iter::ParallelIterator as _;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn report_no_unused_ids_ok() {
+        let ids = HashMap::from([(
+            Atom::Static("foo"),
+            Some(Ranges {
+                range: 0..1,
+                name: 1..2,
+                value: 2..3,
+            }),
+        )]);
+        let referenced_ids = HashSet::from([String::from("foo")]);
+        let report: Vec<_> = no_unused_ids(&ids, &referenced_ids, Severity::Error).collect();
+        assert!(report.is_empty());
+    }
+
+    #[test]
+    fn report_no_unused_ids_error() {
+        let ids = HashMap::from([(
+            Atom::Static("foo"),
+            Some(Ranges {
+                range: 0..1,
+                name: 1..2,
+                value: 2..3,
+            }),
+        )]);
+        let referenced_ids = HashSet::from([]);
+        let report: Vec<_> = no_unused_ids(&ids, &referenced_ids, Severity::Error).collect();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].problem,
+            Problem::UnreferencedId(Atom::Static("foo"))
+        );
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(2..3));
+        assert_eq!(report[0].help, None);
+    }
+}


### PR DESCRIPTION
## Description

Creates a new lint that detects when an element's id is unreferenced

## Motivation and Context

Helps user discover ids that add noise to the document

## How Has This Been Tested?

- Unit tests
- w3c

## Types of changes

### Features

- Adds new lint

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
