### PR TITLE
feat: lint no_unused_xmlns

### DIFF
--- a/crates/oxvg_lint/src/error.rs
+++ b/crates/oxvg_lint/src/error.rs
@@ -53,6 +53,7 @@ pub enum Problem<'input> {
     DefaultAttribute(AttrId<'input>),
     /// There was an `xlink`-prefixed attribute used in the document.
     NoXLink(NoXLinkProblem<'input>),
+    /// There was an `id` value that isn't used anywhere else in the document
     UnreferencedId(Atom<'input>),
 }
 impl Display for Problem<'_> {

--- a/crates/oxvg_lint/src/error.rs
+++ b/crates/oxvg_lint/src/error.rs
@@ -55,6 +55,8 @@ pub enum Problem<'input> {
     NoXLink(NoXLinkProblem<'input>),
     /// There was an `id` value that isn't used anywhere else in the document
     UnreferencedId(Atom<'input>),
+    /// There was an `xmlns` attribute that isn't used by any of its descendants
+    UnreferencedXMLNS(Option<Atom<'input>>, Atom<'input>),
 }
 impl Display for Problem<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -69,6 +71,11 @@ impl Display for Problem<'_> {
             Self::DefaultAttribute(attribute) => f.write_fmt(format_args!("The attribute `{attribute}` has a value that matches its default and can be safely omitted")),
             Self::NoXLink(problem) => problem.fmt(f),
             Self::UnreferencedId(id) => f.write_fmt(format_args!(r#"The id `"{id}"` is not referenced anywhere else in the document"#)),
+            Self::UnreferencedXMLNS(prefix, uri) => f.write_fmt(format_args!(
+                r#"The namespace `xmlns{}{}="{uri}" is not referenced by any descendants`"#,
+                if prefix.is_some() {":"} else {""},
+                prefix.as_deref().unwrap_or("")
+            )),
         }
     }
 }

--- a/crates/oxvg_lint/src/parse.rs
+++ b/crates/oxvg_lint/src/parse.rs
@@ -37,6 +37,7 @@ impl Rules {
             no_default_attributes: Severity::Off,
             no_x_link: Severity::Off,
             no_unused_ids: Severity::Off,
+            no_unused_xmlns: Severity::Off,
         }
     }
 
@@ -49,6 +50,7 @@ impl Rules {
             no_default_attributes: Severity::Warn,
             no_x_link: Severity::Warn,
             no_unused_ids: Severity::Warn,
+            no_unused_xmlns: Severity::Warn,
         }
     }
 

--- a/crates/oxvg_lint/src/rules/mod.rs
+++ b/crates/oxvg_lint/src/rules/mod.rs
@@ -15,6 +15,7 @@ use oxvg_collections::{
     atom::Atom,
     attribute::{Attr, AttrId},
     element::ElementId,
+    name::{Prefix, QualName},
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -26,6 +27,7 @@ mod no_deprecated;
 mod no_unknown_attributes;
 mod no_unknown_elements;
 mod no_unused_ids;
+mod no_unused_xmlns;
 mod no_xlink;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -68,13 +70,18 @@ pub struct Rules {
     #[cfg_attr(feature = "serde", serde(default = "Severity::off"))]
     /// Disallow using id values that are not referenced by the document
     pub no_unused_ids: Severity,
+    #[cfg_attr(feature = "serde", serde(default = "Severity::off"))]
+    /// Disallow using xmlns attributes that are not referenced by the document
+    pub no_unused_xmlns: Severity,
 }
 
+type NamespaceStack<'input> = Vec<HashSet<(Option<Atom<'input>>, Atom<'input>, bool)>>;
 struct Reporter<'o, 'input> {
     rules: &'o Rules,
     reports: RefCell<Vec<Error<'input>>>,
     ids: RefCell<HashMap<Atom<'input>, Option<Ranges>>>,
     referenced_ids: RefCell<HashSet<String>>,
+    xmlns_stack: RefCell<NamespaceStack<'input>>,
 }
 
 pub(crate) struct RuleData<'e, 'input> {
@@ -102,6 +109,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Rules {
             reports: RefCell::default(),
             ids: RefCell::default(),
             referenced_ids: RefCell::default(),
+            xmlns_stack: RefCell::default(),
         };
         for style_sheet in &context.query_has_stylesheet_result {
             style_sheet.borrow_mut().visit(&mut reporter).ok();
@@ -148,23 +156,30 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Reporter<'_, 'input> {
         }
 
         drop(rule_data.attributes);
-        let mut referenced_ids = self.referenced_ids.borrow_mut();
-        for mut attribute in element.attributes().into_iter_mut() {
-            if let Attr::Id(id) = attribute.unaliased() {
-                self.ids.borrow_mut().insert(
-                    id.0.clone(),
-                    rule_data.attribute_ranges.get(&AttrId::Id).cloned(),
-                );
-                continue;
-            }
-            attribute.value_mut().visit_id(|id| {
-                referenced_ids.insert(id.to_string());
-            });
-            attribute.value_mut().visit_url(|url| {
-                if let Some(url) = url.strip_prefix('#') {
-                    referenced_ids.insert(url.to_string());
+        self.track_id_references(element);
+        self.push_xmlns(element);
+        self.track_xmlns(element);
+        Ok(())
+    }
+
+    fn exit_element(
+        &self,
+        element: &Element<'input, 'arena>,
+        _context: &mut Context<'input, 'arena, '_>,
+    ) -> Result<(), Self::Error> {
+        let mut reports = self.reports.borrow_mut();
+        if let Some(namespaces) = self.pop_xmlns() {
+            match self.rules.no_unused_xmlns {
+                Severity::Off => {}
+                severity => {
+                    no_unused_xmlns::no_unused_xmlns(
+                        &mut reports,
+                        element.range().as_ref(),
+                        namespaces,
+                        severity,
+                    );
                 }
-            });
+            }
         }
 
         Ok(())
@@ -207,6 +222,82 @@ impl<'i> lightningcss::visitor::Visitor<'i> for Reporter<'_, '_> {
             self.referenced_ids.borrow_mut().insert(id.to_string());
         }
         Ok(())
+    }
+}
+impl<'input> Reporter<'_, 'input> {
+    fn track_id_references(&self, element: &Element<'input, '_>) {
+        let mut referenced_ids = self.referenced_ids.borrow_mut();
+        let attribute_ranges = element.attribute_ranges();
+        for mut attribute in element.attributes().into_iter_mut() {
+            if let Attr::Id(id) = attribute.unaliased() {
+                self.ids
+                    .borrow_mut()
+                    .insert(id.0.clone(), attribute_ranges.get(&AttrId::Id).cloned());
+                continue;
+            }
+            attribute.value_mut().visit_id(|id| {
+                referenced_ids.insert(id.to_string());
+            });
+            attribute.value_mut().visit_url(|url| {
+                if let Some(url) = url.strip_prefix('#') {
+                    referenced_ids.insert(url.to_string());
+                }
+            });
+        }
+    }
+
+    fn push_xmlns(&self, element: &Element<'input, '_>) {
+        let mut namespaces = HashSet::new();
+        for attr in element.attributes() {
+            match &*attr {
+                Attr::XMLNS(uri) => {
+                    namespaces.insert((None, uri.clone(), false));
+                }
+                Attr::Unparsed {
+                    attr_id:
+                        AttrId::Unknown(QualName {
+                            prefix: Prefix::XMLNS,
+                            local,
+                        }),
+                    value,
+                } => {
+                    namespaces.insert((Some(local.clone()), value.clone(), false));
+                }
+                _ => {}
+            }
+        }
+        self.xmlns_stack.borrow_mut().push(namespaces);
+    }
+    fn track_xmlns(&self, element: &Element<'input, '_>) {
+        let mut xmlns_stack = self.xmlns_stack.borrow_mut();
+        let insert = |xmlns_stack: &mut NamespaceStack<'input>,
+                      name: Option<Atom<'input>>,
+                      uri: &Atom<'input>| {
+            let is_used_group = (name.clone(), uri.clone(), true);
+            let not_used_group = (name, uri.clone(), false);
+
+            for set in xmlns_stack.iter_mut().rev() {
+                if set.contains(&is_used_group) {
+                    break;
+                } else if let Some(mut xmlns) = set.take(&not_used_group) {
+                    xmlns.2 = true;
+                    set.insert(xmlns);
+                }
+            }
+        };
+        for attr in element.attributes() {
+            let prefix = attr.prefix();
+            let name = prefix.value();
+            let uri = prefix.ns().uri();
+            insert(&mut xmlns_stack, name, uri);
+        }
+        let prefix = element.prefix();
+        let name = prefix.value();
+        let uri = prefix.ns().uri();
+        insert(&mut xmlns_stack, name, uri);
+    }
+    fn pop_xmlns(&self) -> Option<HashSet<(Option<Atom<'input>>, Atom<'input>, bool)>> {
+        self.xmlns_stack.borrow_mut().pop()
     }
 }
 

--- a/crates/oxvg_lint/src/rules/mod.rs
+++ b/crates/oxvg_lint/src/rules/mod.rs
@@ -328,8 +328,7 @@ impl Severity {
     }
 }
 
-#[cfg(debug_assertions)]
-#[allow(dead_code)]
+#[cfg(test)]
 struct TestData<'input> {
     reports: RefCell<Vec<Error<'input>>>,
     parent: Option<ElementId<'input>>,

--- a/crates/oxvg_lint/src/rules/no_unknown_elements.rs
+++ b/crates/oxvg_lint/src/rules/no_unknown_elements.rs
@@ -1,73 +1,76 @@
-use oxvg_collections::{element::ElementId, is_prefix};
+use oxvg_collections::is_prefix;
 
 use crate::{
     error::{Error, Problem},
     utils::prefix_help,
 };
 
-use super::Severity;
+use super::{RuleData, Severity};
 
 pub fn no_unknown_elements<'input>(
-    parent: Option<&ElementId<'input>>,
-    name: &ElementId<'input>,
-    range: Option<&std::ops::Range<usize>>,
+    RuleData {
+        reports,
+        parent,
+        element,
+        range,
+        ..
+    }: &mut RuleData<'_, 'input>,
     severity: Severity,
-) -> Option<Error<'input>> {
-    let parent = parent?;
-    if !is_prefix!(name.prefix(), SVG) {
-        return None;
+) {
+    let Some(parent) = parent else {
+        return;
+    };
+    if !is_prefix!(element.prefix(), SVG) {
+        return;
     }
 
-    if parent.is_permitted_child(name) {
-        return None;
+    if parent.is_permitted_child(element) {
+        return;
     }
-    Some(Error {
+    reports.push(Error {
         problem: Problem::UnknownElement {
             parent: parent.clone(),
-            element: name.clone(),
+            element: (*element).clone(),
         },
         severity,
         // NOTE: roxmltree range spans from the start of the opening-tag to the end of the closing-tag
-        //       Using a zero-len range will cause the error reporter to use `utils::naive_range`.
-        range: range.map(|range| range.start..range.start),
-        help: prefix_help(name.prefix()),
+        //       Using a zero-length range will cause the error reporter to use `utils::naive_range`.
+        range: range.as_ref().map(|range| range.start..range.start),
+        help: prefix_help(element.prefix()),
     })
 }
 
 #[cfg(test)]
 mod test {
     use super::no_unknown_elements;
-    use crate::{error::Problem, Severity};
+    use crate::{error::Problem, rules::RuleData, Severity};
     use oxvg_collections::element::ElementId;
 
-    static PARENT_ELEMENT: Option<ElementId<'static>> = Some(ElementId::Svg);
-    static KNOWN_ELEMENT: ElementId<'static> = ElementId::Circle;
-    static UNKNOWN_ELEMENT: ElementId<'static> = ElementId::Stop;
+    const PARENT_ELEMENT: Option<ElementId<'static>> = Some(ElementId::Svg);
+    const KNOWN_ELEMENT: ElementId<'static> = ElementId::Circle;
+    const UNKNOWN_ELEMENT: ElementId<'static> = ElementId::Stop;
 
     #[test]
     fn report_unknown_element_ok() {
-        let report = no_unknown_elements(
-            PARENT_ELEMENT.as_ref(),
-            &KNOWN_ELEMENT,
-            None,
-            Severity::Error,
-        );
-        assert!(report.is_none());
+        let mut test_data = RuleData::test_data();
+        test_data.element = KNOWN_ELEMENT;
+        let mut test_data = RuleData::from_test_data(&test_data);
+        no_unknown_elements(&mut test_data, Severity::Error);
+        assert!(test_data.reports.is_empty());
     }
     #[test]
     fn report_unknown_element() {
-        let report = no_unknown_elements(
-            PARENT_ELEMENT.as_ref(),
-            &UNKNOWN_ELEMENT,
-            Some(&(0..1)),
-            Severity::Error,
-        )
-        .unwrap();
+        let mut test_data = RuleData::test_data();
+        test_data.element = UNKNOWN_ELEMENT;
+        let mut test_data = RuleData::from_test_data(&test_data);
+        no_unknown_elements(&mut test_data, Severity::Error);
+        assert_eq!(test_data.reports.len(), 1);
+        let report = test_data.reports.first().unwrap();
         assert_eq!(
             report.problem,
             Problem::UnknownElement {
-                parent: PARENT_ELEMENT.clone().unwrap(),
-                element: UNKNOWN_ELEMENT.clone(),
+                parent: PARENT_ELEMENT.unwrap(),
+                element: UNKNOWN_ELEMENT,
             }
         );
         assert_eq!(report.severity, Severity::Error);

--- a/crates/oxvg_lint/src/rules/no_unused_xmlns.rs
+++ b/crates/oxvg_lint/src/rules/no_unused_xmlns.rs
@@ -1,0 +1,73 @@
+use std::{collections::HashSet, ops::Range};
+
+use oxvg_collections::atom::Atom;
+use rayon::prelude::*;
+
+use crate::error::{Error, Problem};
+
+use super::Severity;
+
+pub fn no_unused_xmlns<'input>(
+    reports: &mut Vec<Error<'input>>,
+    range: Option<&Range<usize>>,
+    mut xmlns_set: HashSet<(Option<Atom<'input>>, Atom<'input>, bool)>,
+    severity: Severity,
+) {
+    let range = range.map(|r| r.start..r.start);
+    reports.par_extend(
+        xmlns_set
+            .par_drain()
+            .filter_map(move |(prefix, uri, is_used)| {
+                if is_used {
+                    None
+                } else {
+                    Some(Error {
+                        problem: Problem::UnreferencedXMLNS(prefix, uri),
+                        severity,
+                        range: range.clone(),
+                        help: None,
+                    })
+                }
+            }),
+    );
+}
+
+#[cfg(test)]
+mod test {
+    use super::no_unused_xmlns;
+    use crate::{error::Problem, Severity};
+    use oxvg_collections::atom::Atom;
+    use std::collections::HashSet;
+
+    const PREFIX: Option<Atom> = Some(Atom::Static("foo"));
+    const LOCAL: Atom = Atom::Static("bar");
+
+    #[test]
+    fn report_no_unused_xmlns_ok() {
+        let mut reports = Vec::new();
+        let xmlns_set = HashSet::from([(PREFIX, LOCAL, true)]);
+
+        no_unused_xmlns(
+            &mut reports,
+            Some(0..1).as_ref(),
+            xmlns_set,
+            Severity::Error,
+        );
+
+        assert!(reports.is_empty());
+    }
+
+    #[test]
+    fn report_no_unused_xmlns_error() {
+        let mut report = Vec::new();
+        let xmlns_set = HashSet::from([(PREFIX, LOCAL, false)]);
+
+        no_unused_xmlns(&mut report, Some(0..1).as_ref(), xmlns_set, Severity::Error);
+
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].problem, Problem::UnreferencedXMLNS(PREFIX, LOCAL));
+        assert_eq!(report[0].severity, Severity::Error);
+        assert_eq!(report[0].range, Some(0..0));
+        assert_eq!(report[0].help, None);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

Creates a new lint that detects when a namespace is unused

## Motivation and Context

Helps users discover namespaces that add noise to the document

## How Has This Been Tested?

- Unit tests
- Editor
- w3c

## Types of changes
### Fixes

- Refactor linting APIs

### Features

- Adds new lint

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
