### PR TITLE
fix: fix format always exiting with error

### DIFF
--- a/crates/oxvg/src/commands/format.rs
+++ b/crates/oxvg/src/commands/format.rs
@@ -93,7 +93,9 @@ impl RunCommand for Format {
                         Ok(())
                     },
                 );
-                error.store(true, Ordering::Relaxed);
+                if matches!(result, Err(_) | Ok(Err(_))) {
+                    error.store(true, Ordering::Relaxed);
+                }
                 match result {
                     Err(err) => eprintln!("{err}"),
                     Ok(Err(err)) => eprintln!("{err}"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

Fixes issue where error was always being set in format command

## Motivation and Context

Changes to correct behaviour

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- see [correctness](https://github.com/noahbald/oxvg/wiki/Correctness) for thorough testing -->

## Types of changes
### Fixes

- Fixes error

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
