### PR TITLE
fix: #214 fix bytes being reported as kb

### DIFF
--- a/crates/oxvg/src/commands/format.rs
+++ b/crates/oxvg/src/commands/format.rs
@@ -87,7 +87,7 @@ impl RunCommand for Format {
                             dom,
                             input: path,
                             destination: output,
-                            input_size: source.len() as f64,
+                            input_bytes: source.len() as f64,
                         };
                         output.output()?;
                         Ok(())

--- a/crates/oxvg/src/commands/optimise.rs
+++ b/crates/oxvg/src/commands/optimise.rs
@@ -108,7 +108,7 @@ impl Optimise {
                         ..ParsingOptions::default()
                     },
                     |dom, allocator| -> anyhow::Result<()> {
-                        let input_size = source.len() as f64;
+                        let input_bytes = source.len() as f64;
                         let info = Info {
                             path: path.cloned(),
                             multipass_count: 0,
@@ -122,7 +122,7 @@ impl Optimise {
                             dom,
                             input: path,
                             destination: output,
-                            input_size,
+                            input_bytes,
                         };
                         output.output()?;
                         Ok(())

--- a/crates/oxvg/src/walk.rs
+++ b/crates/oxvg/src/walk.rs
@@ -35,12 +35,11 @@ pub(crate) struct Output<'a, 'input, 'arena> {
     pub dom: Ref<'input, 'arena>,
     pub input: Option<&'a PathBuf>,
     pub destination: Option<&'a PathBuf>,
-    pub input_size: f64,
+    pub input_bytes: f64,
 }
 impl Output<'_, '_, '_> {
     pub fn output(self) -> anyhow::Result<()> {
         let is_stdin = self.input.is_none();
-        let input_size = self.input_size;
         if let Some(output) = self.destination {
             if is_stdin && output.metadata().is_ok_and(|f| f.is_dir()) {
                 eprintln!("Cannot use dir as output with stdin. Printing result to stdout instead");
@@ -52,12 +51,13 @@ impl Output<'_, '_, '_> {
                 let file = std::fs::File::create(output)?;
                 self.dom.serialize_into(file, self.options)?;
 
-                let output_size = output.metadata()?.len() as f64 / 1000.0;
-                let change = 100.0 * (input_size - output_size) / input_size;
+                let input_kb = self.input_bytes / 1000.0;
+                let output_kb = output.metadata()?.len() as f64 / 1000.0;
+                let change = 100.0 * (input_kb - output_kb) / input_kb;
                 let increased = if change < 0.0 { "\x1b[31m" } else { "" };
                 let path = self.input.and_then(|p| p.to_str()).unwrap_or("");
                 println!(
-            "\n\n\x1b[32m{path:?} ({input_size:.1}KB) -> {output:?} ({output_size:.1}KB) {increased}({change:.2}%)\x1b[0m"
+            "\n\n\x1b[32m{path:?} ({input_kb:.1}KB) -> {output:?} ({output_kb:.1}KB) {increased}({change:.2}%)\x1b[0m"
                 );
             }
         } else {


### PR DESCRIPTION
## Description

This PR reports input filesize as the correct around of kb, instead of 1000x times larger than it actually is.

## Motivation and Context

Fixes incorrect behaviour

## How Has This Been Tested?

- Running `oxvg optimise`

## Types of changes
### Fixes

- Fixes input size reporting

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
