### PR TITLE
Moving log release_max_level_off from workspace level to oxvg applica…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ lightningcss = { version = "1.0.0-alpha.63", default-features = false, features 
   "grid",
   "visitor",
 ] }
-log = { version = "0.4", features = ["release_max_level_off"] }
+log = { version = "0.4" }
 lsp-types = "0.97"
 markup5ever = "0.14"
 napi = { version = "3.4", default-features = false, features = ["napi7"] }

--- a/crates/oxvg/Cargo.toml
+++ b/crates/oxvg/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 etcetera = "0.10"
 ignore = "0.4"
-log = { workspace = true }
+log = { workspace = true, features = ["release_max_level_off"] }
 roxmltree = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Moves the release_max_level_off feature activation on the log crate from workspace level to specifically the oxvg application binary. Fixes #218.