### PR TITLE
fix: #222 fix issue where space-seperated list failed with training whitespace

### DIFF
--- a/crates/oxvg_collections/src/attribute/list_of.rs
+++ b/crates/oxvg_collections/src/attribute/list_of.rs
@@ -240,6 +240,10 @@ impl<'input, T: Parse<'input> + std::fmt::Debug + PartialEq, S: Separator> Parse
             Err(e) => return Err(e),
         };
         loop {
+            if input.slice().trim_end().is_empty() {
+                S::maybe_skip_whitespace(input);
+                break;
+            }
             if S::parse(input).is_err() {
                 break;
             }
@@ -449,5 +453,29 @@ fn list_of_semicolon() {
     assert_eq!(
         ListOf::<i64, Semicolon>::parse_string("1,2,3"),
         Err(Error::ExpectedDone)
+    );
+}
+
+#[test]
+fn list_of_non_whitespace() {
+    use crate::{atom::Atom, attribute::core::NonWhitespace};
+
+    assert_eq!(
+        ListOf::<NonWhitespace, Space>::parse_string("a "),
+        Ok(ListOf {
+            list: vec![NonWhitespace(Atom::Static("a"))],
+            separator: Space
+        })
+    );
+
+    assert_eq!(
+        ListOf::<NonWhitespace, Space>::parse_string(" a b "),
+        Ok(ListOf {
+            list: vec![
+                NonWhitespace(Atom::Static("a")),
+                NonWhitespace(Atom::Static("b"))
+            ],
+            separator: Space
+        })
     );
 }


### PR DESCRIPTION
## Description

Fixes an issue where parsing `ListOf<_, Space>` would fail when trailing white-space was present.

Closes #222 

## Motivation and Context

- Prevents failure parsing `Class` and other types when trailing white-space is present

## How Has This Been Tested?

- Unit tests

## Types of changes
### Fixes

- Fixes list-of parsing

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
