### PR TITLE
fix(napi): fix incorrect cpu arch

### DIFF
--- a/packages/napi/npm/darwin-arm64/package.json
+++ b/packages/napi/npm/darwin-arm64/package.json
@@ -5,7 +5,7 @@
 		"url": "git+https://github.com/noahbald/oxvg.git"
 	},
 	"os": ["darwin"],
-	"cpu": ["x64"],
+	"cpu": ["arm64"],
 	"main": "oxvg.darwin-arm64.node",
 	"files": ["oxvg.darwin-arm64.node"],
 	"license": "MIT",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

The `cpu` field is incorrect in the `package.json` of `@oxvg/napi-darwin-arm64`.

## Motivation and Context

On my Silicon Mac, `@oxvg/napi` was installed, but `@oxvg/napi-darwin-arm64` was not installed.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- see [correctness](https://github.com/noahbald/oxvg/wiki/Correctness) for thorough testing -->

## Types of changes
### Fixes
<!-- List non-breaking changes which fixes an issue -->

### Features
<!-- List non-breaking changes which add functionality) -->

### Breaking changes
<!-- List fixes or features that would cause existing functionality to change -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [ ] All new and existing tests passed.
