### PR TITLE
fix(ast): make ComputedStyles conversions fallible instead of panicking

### DIFF
--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -318,45 +318,35 @@ impl<'input> ComputedStyles<'input> {
 
     /// Gets the resolved style from a presentation attribute id.
     ///
-    /// # Panics
-    ///
-    /// If conversions between property and attr fail
+    /// A css value that cannot be converted back into a presentation
+    /// attribute (e.g. `fill: var(--c, #fff)` — `var()` with a fallback in a
+    /// `style` attribute) resolves to `None` ("unknown"), NOT to a
+    /// lower-priority source, which could disagree with what a browser
+    /// resolves.
     pub fn get(&self, id: &AttrId) -> Option<(Attr<'input>, Mode)> {
         debug_assert!(id.attribute_group().contains(AttributeGroup::Presentation));
         let property_id = id.into();
-        self.get_from_css_high_priori(&property_id)
-            .map(|(css, mode)| {
-                (
-                    css.try_into()
-                        .expect("attr convertible to property should also be able to convert back"),
-                    mode,
-                )
-            })
-            .or_else(|| {
-                self.get_from_css_low_priori(&property_id)
-                    .map(|(css, mode)| (css.try_into().unwrap(), mode))
-            })
-            .or_else(|| self.get_from_attr(id))
-            .or_else(|| {
-                // 7. Inherited
-                self.get_inherited(id.local_name())
-            })
+        if let Some((css, mode)) = self.get_from_css_high_priori(&property_id) {
+            return css.try_into().ok().map(|attr| (attr, mode));
+        }
+        if let Some((css, mode)) = self.get_from_css_low_priori(&property_id) {
+            return css.try_into().ok().map(|attr| (attr, mode));
+        }
+        self.get_from_attr(id).or_else(|| {
+            // 7. Inherited
+            self.get_inherited(id.local_name())
+        })
     }
 
     /// Gets a computed style as a property if there's a matching [`PropertyId`]
     ///
-    /// # Panics
-    ///
-    /// If conversions between property and attr fail
+    /// As with [`ComputedStyles::get`], a value that cannot be converted
+    /// resolves to `None` rather than panicking.
     pub fn get_by_property(&self, id: &PropertyId) -> Option<(Property<'input>, Mode)> {
         if let Ok(attr_id) = id.try_into() {
-            return self.get(&attr_id).map(|(attr, mode)| {
-                (
-                    attr.try_into()
-                        .expect("property convertible to attr should also be able to convert back"),
-                    mode,
-                )
-            });
+            return self
+                .get(&attr_id)
+                .and_then(|(attr, mode)| attr.try_into().ok().map(|prop| (prop, mode)));
         }
         self.get_from_css_high_priori(id)
             .or_else(|| self.get_from_css_low_priori(id))

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -380,5 +380,17 @@ fn remove_useless_stroke_and_fill() -> anyhow::Result<()> {
         ),
     )?);
 
+    insta::assert_snapshot!(test_config(
+        r#"{ "removeUselessStrokeAndFill": {} }"#,
+        Some(
+            r##"<svg xmlns="http://www.w3.org/2000/svg">
+    <!-- don't panic on a style value that has no presentation-attribute form:
+         `var()` with a fallback (previously: "attr convertible to property
+         should also be able to convert back" in oxvg_ast::style) -->
+    <path fill="#fff" style="fill:var(--c,#fff)" d="M1,1 L2.123456,2.654321"/>
+</svg>"##
+        ),
+    )?);
+
     Ok(())
 }

--- a/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_useless_stroke_and_fill__remove_useless_stroke_and_fill-6.snap
+++ b/crates/oxvg_optimiser/src/jobs/snapshots/oxvg_optimiser__jobs__remove_useless_stroke_and_fill__remove_useless_stroke_and_fill-6.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+assertion_line: 383
+expression: "test_config(r#\"{ \"removeUselessStrokeAndFill\": {} }\"#,\nSome(r##\"<svg xmlns=\"http://www.w3.org/2000/svg\">\n    <!-- don't panic on a style value that has no presentation-attribute form:\n         `var()` with a fallback (previously: \"attr convertible to property\n         should also be able to convert back\" in oxvg_ast::style) -->\n    <path fill=\"#fff\" style=\"fill:var(--c,#fff)\" d=\"M1,1 L2.123456,2.654321\"/>\n</svg>\"##),)?"
+---
+<svg xmlns="http://www.w3.org/2000/svg">
+    <!-- don't panic on a style value that has no presentation-attribute form:
+         `var()` with a fallback (previously: "attr convertible to property
+         should also be able to convert back" in oxvg_ast::style) -->
+    <path fill="#fff" style="fill:var(--c,#fff)" d="M1 1 2.123456 2.654321"/>
+</svg>


### PR DESCRIPTION
ComputedStyles::get and ::get_by_property called .expect()/.unwrap() on the css<->attr round-trip conversion. A style value with no presentation-attribute form — e.g. fill:var(--c,#fff), a CSS custom property WITH a fallback, in a style attribute — made the conversion fail and panicked the whole optimizer at oxvg_ast/src/style.rs:331 ('attr convertible to property should also be able to convert back'), reachable from preset-default via removeUselessStrokeAndFill on real-world icon sprites (e.g. www.din.de's 102-symbol sprite).

An unconvertible value now resolves to None ('unknown style') rather than falling through to a lower-priority source, which could resolve a value the browser would not. Regression test added on removeUselessStrokeAndFill.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- see [correctness](https://github.com/noahbald/oxvg/wiki/Correctness) for thorough testing -->

## Types of changes
### Fixes
<!-- List non-breaking changes which fixes an issue -->

### Features
<!-- List non-breaking changes which add functionality) -->

### Breaking changes
<!-- List fixes or features that would cause existing functionality to change -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [ ] All new and existing tests passed.
