### PR TITLE
fix! #236 svgo conversion inconsistencies

### DIFF
--- a/crates/oxvg_optimiser/src/jobs/minify_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/minify_styles.rs
@@ -70,7 +70,7 @@ pub struct MinifyStyles {
     /// Whether to remove styles with no matching elements.
     #[cfg_attr(feature = "wasm", tsify(type = r#"boolean | "force""#, optional))]
     #[cfg_attr(feature = "serde", serde(default = "RemoveUnused::default"))]
-    pub remove_unused: RemoveUnused,
+    pub usage: RemoveUnused,
 }
 
 #[derive(Debug)]
@@ -125,7 +125,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
                 .insert(element.id(), element.clone());
         }
 
-        if matches!(self.options.remove_unused, RemoveUnused::False) {
+        if matches!(self.options.usage, RemoveUnused::False) {
             return Ok(());
         }
 
@@ -160,7 +160,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
             let mut style_sheet = style_sheet.borrow_mut();
 
             let mut visitor = StyleVisitor(self);
-            match self.options.remove_unused {
+            match self.options.usage {
                 RemoveUnused::True
                     if !context
                         .flags
@@ -355,7 +355,7 @@ fn minify_styles() -> anyhow::Result<()> {
     )?);
 
     insta::assert_snapshot!(test_config(
-        r#"{ "minifyStyles": { "removeUnused": false } }"#,
+        r#"{ "minifyStyles": { "usage": false } }"#,
         Some(
             r#"<svg xmlns="http://www.w3.org/2000/svg">
     <style>
@@ -407,7 +407,7 @@ fn minify_styles() -> anyhow::Result<()> {
     )?);
 
     insta::assert_snapshot!(test_config(
-        r#"{ "minifyStyles": { "removeUnused": "force" } }"#,
+        r#"{ "minifyStyles": { "usage": "force" } }"#,
         Some(
             r#"<svg xmlns="http://www.w3.org/2000/svg">
     <style>

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -92,19 +92,36 @@ macro_rules! jobs {
                                 return Err(napi::Error::new(Status::InvalidArg, "expected name to be string"));
                             };
                             let name = Self::from_svgo_plugin_to_snake_case(&svgo_name);
-                            match name.as_str() {
-                                $(stringify!($name) => oxvg_config.$name = Some(plugin.get("params")?.unwrap_or_default()),)+
-                                _ => return Err(napi::Error::new(Status::InvalidArg, format!("unknown job `{name}`"))),
-                            }
                             if matches!(name.as_str(), "convert_path_data") {
-                                if let Ok(Some(params)) = plugin.get::<Object>("params") {
-                                    if matches!(plugin.get::<bool>("applyTransforms"), Ok(Some(true))) {
+                                if let Some(params) = plugin.get::<Object>("params")? {
+                                    let mut convert_path_data: ConvertPathData = plugin.get("params").ok().flatten().unwrap_or_default();
+                                    let make_arcs = params.get::<Object>("makeArcs").ok().flatten();
+                                    if let Some(make_arcs) = make_arcs {
+                                        convert_path_data.tolerance.positional = make_arcs.get("threshold").ok().flatten().unwrap_or(convert_path_data.tolerance.positional);
+                                    }
+                                    convert_path_data.tolerance.precision = params.get("floatPrecision").ok().flatten().unwrap_or(convert_path_data.tolerance.precision);
+                                    convert_path_data.close_segments = params.get("convertToZ").ok().flatten().unwrap_or(convert_path_data.close_segments);
+                                    convert_path_data.join_nodes = params.get("collapseRepeated").ok().flatten().unwrap_or(convert_path_data.join_nodes);
+                                    convert_path_data.remove_empty_segments = params.get("removeUseless").ok().flatten().unwrap_or(convert_path_data.remove_empty_segments);
+                                    convert_path_data.remove_zero_segments = params.get("removeUseless").ok().flatten().unwrap_or(convert_path_data.remove_zero_segments);
+                                    convert_path_data.remove_close_line = params.get("removeUseless").ok().flatten().unwrap_or(convert_path_data.remove_close_line);
+                                    convert_path_data.straight_curves = params.get("straightCurves").ok().flatten().unwrap_or(convert_path_data.straight_curves);
+                                    convert_path_data.arc_curves = make_arcs.is_some();
+                                    convert_path_data.smart_arc_rounding = params.get("smartArcRounding").ok().flatten().unwrap_or(convert_path_data.smart_arc_rounding);
+                                    oxvg_config.convert_path_data = Some(convert_path_data);
+
+                                    if matches!(params.get::<bool>("applyTransforms"), Ok(Some(true))) {
                                         oxvg_config.apply_transforms = Some(ApplyTransforms {
                                             transform_precision: params.get("transformPrecision")?,
                                             apply_transforms_stroked:
                                                 params.get("applyTransformsStroked")?.unwrap_or_default(),
                                         });
                                     }
+                                }
+                            } else {
+                                match name.as_str() {
+                                    $(stringify!($name) => oxvg_config.$name = Some(plugin.get("params")?.unwrap_or_default()),)+
+                                    _ => return Err(napi::Error::new(Status::InvalidArg, format!("unknown job `{name}`"))),
                                 }
                             }
                         }
@@ -152,7 +169,23 @@ macro_rules! jobs {
                             let params = plugin.remove("params");
                             if let Some(mut params) = params {
                                 if matches!(name.as_str(), "convert_path_data") {
+                                    let mut convert_path_data: ConvertPathData = serde_json::from_value(params.clone()).unwrap_or_default();
                                     if let serde_json::Value::Object(params) = &mut params {
+                                        let mut make_arcs = params.remove("makeArcs");
+                                        if let Some(serde_json::Value::Object(make_arcs)) = make_arcs.as_mut() {
+                                            convert_path_data.tolerance.positional = make_arcs.remove("threshold").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.tolerance.positional);
+                                        }
+                                        convert_path_data.tolerance.precision = params.remove("floatPrecision").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.tolerance.precision);
+                                        convert_path_data.close_segments = params.remove("convertToZ").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.close_segments);
+                                        convert_path_data.join_nodes = params.remove("collapseRepeated").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.join_nodes);
+                                        convert_path_data.remove_empty_segments = params.remove("removeUseless").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.remove_empty_segments);
+                                        convert_path_data.remove_zero_segments = params.remove("removeUseless").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.remove_zero_segments);
+                                        convert_path_data.remove_close_line = params.remove("removeUseless").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.remove_close_line);
+                                        convert_path_data.straight_curves = params.remove("straightCurves").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.straight_curves);
+                                        convert_path_data.arc_curves = make_arcs.is_some();
+                                        convert_path_data.smart_arc_rounding = params.remove("smartArcRounding").map(serde_json::from_value).and_then(Result::ok).unwrap_or(convert_path_data.smart_arc_rounding);
+                                        oxvg_config.convert_path_data = Some(convert_path_data);
+
                                         if matches!(
                                             params.remove("applyTransforms"),
                                             Some(serde_json::Value::Bool(true)),
@@ -166,10 +199,11 @@ macro_rules! jobs {
                                             });
                                         }
                                     }
-                                }
-                                match name.as_str() {
-                                    $(stringify!($name) => oxvg_config.$name = Some(serde_json::from_value(params)?),)+
-                                    _ => return Err(serde_json::Error::custom(format!("unknown job `{name}`"))),
+                                } else {
+                                    match name.as_str() {
+                                        $(stringify!($name) => oxvg_config.$name = Some(serde_json::from_value(params)?),)+
+                                        _ => return Err(serde_json::Error::custom(format!("unknown job `{name}`"))),
+                                    }
                                 }
                             } else {
                                 match name.as_str() {

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -96,6 +96,17 @@ macro_rules! jobs {
                                 $(stringify!($name) => oxvg_config.$name = Some(plugin.get("params")?.unwrap_or_default()),)+
                                 _ => return Err(napi::Error::new(Status::InvalidArg, format!("unknown job `{name}`"))),
                             }
+                            if matches!(name.as_str(), "convert_path_data") {
+                                if let Ok(Some(params)) = plugin.get::<Object>("params") {
+                                    if matches!(plugin.get::<bool>("applyTransforms"), Ok(Some(true))) {
+                                        oxvg_config.apply_transforms = Some(ApplyTransforms {
+                                            transform_precision: params.get("transformPrecision")?,
+                                            apply_transforms_stroked:
+                                                params.get("applyTransformsStroked")?.unwrap_or_default(),
+                                        });
+                                    }
+                                }
+                            }
                         }
                         _ => return Err(napi::Error::new(Status::InvalidArg, "unexpected type")),
                     }
@@ -139,7 +150,23 @@ macro_rules! jobs {
                             };
                             let name = Self::from_svgo_plugin_to_snake_case(&svgo_name);
                             let params = plugin.remove("params");
-                            if let Some(params) = params {
+                            if let Some(mut params) = params {
+                                if matches!(name.as_str(), "convert_path_data") {
+                                    if let serde_json::Value::Object(params) = &mut params {
+                                        if matches!(
+                                            params.remove("applyTransforms"),
+                                            Some(serde_json::Value::Bool(true)),
+                                        ) {
+                                            oxvg_config.apply_transforms = Some(ApplyTransforms {
+                                                transform_precision: params.remove("transformPrecision")
+                                                    .and_then(|p| serde_json::from_value(p).ok()),
+                                                apply_transforms_stroked: params.remove("applyTransformsStroked")
+                                                    .and_then(|p| serde_json::from_value(p).ok())
+                                                    .unwrap_or_default()
+                                            });
+                                        }
+                                    }
+                                }
                                 match name.as_str() {
                                     $(stringify!($name) => oxvg_config.$name = Some(serde_json::from_value(params)?),)+
                                     _ => return Err(serde_json::Error::custom(format!("unknown job `{name}`"))),
@@ -149,6 +176,9 @@ macro_rules! jobs {
                                     $(stringify!($name) => oxvg_config.$name = Some($job::default()),)+
                                     _ => return Err(serde_json::Error::custom(format!("unknown job `{name}`"))),
                                 };
+                                if matches!(name.as_str(), "convert_path_data") {
+                                    oxvg_config.apply_transforms = Some(ApplyTransforms::default());
+                                }
                             }
                         }
                         _ => return Err(serde_json::Error::custom(format!("unexpected type"))),
@@ -174,6 +204,9 @@ macro_rules! jobs {
                     $(stringify!($name) => self.$name = Some($job::default()),)+
                     _ => return Err(()),
                 };
+                if matches!(name.as_str(), "convert_path_data") {
+                    self.apply_transforms = Some(ApplyTransforms::default());
+                }
                 Ok(())
             }
 

--- a/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
@@ -15,7 +15,7 @@ use tsify::Tsify;
 
 use crate::error::JobsError;
 
-const fn default_remove_unsafe() -> bool {
+const fn default_remove_any() -> bool {
     false
 }
 
@@ -87,7 +87,7 @@ impl<'input> AttrStylesheet<'input> {
 ///
 /// By default this job should never visually change the document.
 ///
-/// Specifying `remove_unsafe` may remove attributes which visually change
+/// Specifying `remove_any` may remove attributes which visually change
 /// the document.
 ///
 /// # Errors
@@ -96,15 +96,15 @@ impl<'input> AttrStylesheet<'input> {
 ///
 /// If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
 pub struct RemoveDeprecatedAttrs {
-    #[cfg_attr(feature = "serde", serde(default = "default_remove_unsafe"))]
-    /// Whether to remove deprecated presentation attributes
-    pub remove_unsafe: bool,
+    #[cfg_attr(feature = "serde", serde(default = "default_remove_any"))]
+    /// Whether to remove deprecated presentation attributes that may be unsafe to remove
+    pub remove_any: bool,
 }
 
 impl Default for RemoveDeprecatedAttrs {
     fn default() -> Self {
         RemoveDeprecatedAttrs {
-            remove_unsafe: default_remove_unsafe(),
+            remove_any: default_remove_any(),
         }
     }
 }
@@ -154,7 +154,7 @@ impl RemoveDeprecatedAttrs {
             }
             let info = attr.name().info();
             if info.contains(AttributeInfo::DeprecatedSafe)
-                || (self.remove_unsafe && info.contains(AttributeInfo::DeprecatedUnsafe))
+                || (self.remove_any && info.contains(AttributeInfo::DeprecatedUnsafe))
             {
                 return false;
             }
@@ -188,7 +188,7 @@ fn remove_attrs() -> anyhow::Result<()> {
     )?);
 
     insta::assert_snapshot!(test_config(
-        r#"{ "removeDeprecatedAttrs": { "removeUnsafe": true } }"#,
+        r#"{ "removeDeprecatedAttrs": { "removeAny": true } }"#,
         Some(
             r#"<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
     <!-- removes unsafe to remove deprecated `viewTarget` -->
@@ -198,7 +198,7 @@ fn remove_attrs() -> anyhow::Result<()> {
     )?);
 
     insta::assert_snapshot!(test_config(
-        r#"{ "removeDeprecatedAttrs": { "removeUnsafe": true } }"#,
+        r#"{ "removeDeprecatedAttrs": { "removeAny": true } }"#,
         Some(
             r#"<svg xmlns="http://www.w3.org/2000/svg" width="100.5" height=".5" enable-background="new 0 0 100.5 .5">
     <!-- remove deprecated `enable-background` -->
@@ -233,7 +233,7 @@ fn remove_attrs() -> anyhow::Result<()> {
     )?);
 
     insta::assert_snapshot!(test_config(
-        r#"{ "removeDeprecatedAttrs": { "removeUnsafe": true } }"#,
+        r#"{ "removeDeprecatedAttrs": { "removeAny": true } }"#,
         Some(
             r#"<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
     <!-- removes unsafe to remove deprecated `xml:lang` -->
@@ -243,7 +243,7 @@ fn remove_attrs() -> anyhow::Result<()> {
     )?);
 
     insta::assert_snapshot!(test_config(
-        r#"{ "removeDeprecatedAttrs": { "removeUnsafe": true } }"#,
+        r#"{ "removeDeprecatedAttrs": { "removeAny": true } }"#,
         Some(
             r#"<svg version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
     <!-- keep selected `version` -->

--- a/packages/napi/index.d.ts
+++ b/packages/napi/index.d.ts
@@ -1250,40 +1250,26 @@ export interface ConvertOneStopGradients {
  * Rounding errors may result in slight visual differences.
  */
 export interface ConvertPathData {
-  /** Whether to remove redundant path commands. */
-  removeUseless: boolean
-  /** Whether to round the radius of circular arcs when the effective change is under error bounds. */
-  smartArcRounding: boolean
-  /** Whether to convert straight curves to lines */
+  /** Whether to close unclosed paths segments when safe to do so. */
+  closeSegments: boolean
+  /** Whether to boolean unite overlapping segments when safe and optimal to do so (experimental). */
+  uniteSegments: boolean
+  /** Whether to join commands that fit within it's neighboring commands when safe to do so. */
+  joinNodes: boolean
+  /** Whether to remove move commands neighbored by move commands when safe to do so. */
+  removeEmptySegments: boolean
+  /** Whether to remove segments where all command args are effectively zero. */
+  removeZeroSegments: boolean
+  /** Whether to remove closing lines when safe to do so. */
+  removeCloseLine: boolean
+  /** Whether to convert curves and arcs into lines. */
   straightCurves: boolean
-  /** Whether to convert complex curves that look like cubic beziers (q) into them. */
-  convertToQ: boolean
-  /** Whether to convert normal lines that move in one direction to a vertical or horizontal line command. */
-  lineShorthands: boolean
-  /** Whether merge repeated commands into one. */
-  collapseRepeated: boolean
-  /** Whether to convert complex curves that look like smooth curves into them. */
-  curveSmoothShorthands: boolean
-  /** Whether to convert lines that close a curve to a close command (z). */
-  convertToZ: boolean
-  /** Whether to always convert relative paths to absolute, even if larger. */
-  forceAbsolutePath: boolean
-  /** Whether to weakly force absolute commands, when slightly suboptimal */
-  negativeExtraSpace: boolean
-  /** Controls whether to convert from curves to arcs */
-  makeArcs: MakeArcs
-  /**
-   * Number of decimal places to round to.
-   *
-   * Precisions larger than 20 will be treated as 0.
-   */
-  floatPrecision: ConvertPrecision
-  /** Whether to convert from relative to absolute, when shorter. */
-  utilizeAbsolute: boolean
-}
-
-export interface ConvertPrecision {
-  field0: Precision
+  /** Whether to convert curves curves into arcs. */
+  arcCurves: boolean
+  /** Whether to loosen arc radius rounding based on chord length. */
+  smartArcRounding: boolean
+  /** Tolerance for converting between SVG, Segments, and Polygons. */
+  tolerance: Tolerance
 }
 
 /**
@@ -1308,7 +1294,7 @@ export interface ConvertShapeToPath {
   /** Whether to convert `<circle>` and `<ellipses>` to paths. */
   convertArcs: boolean
   /** The number of decimal places to round to */
-  floatPrecision: ConvertPrecision
+  floatPrecision: number
 }
 
 /**
@@ -1554,7 +1540,7 @@ export type Method =
  */
 export interface MinifyStyles {
   /** Whether to remove styles with no matching elements. */
-  removeUnused: RemoveUnused
+  usage: RemoveUnused
 }
 
 /**
@@ -1746,7 +1732,7 @@ export interface RemoveComments {
  *
  * By default this job should never visually change the document.
  *
- * Specifying `remove_unsafe` may remove attributes which visually change
+ * Specifying `remove_any` may remove attributes which visually change
  * the document.
  *
  * # Errors
@@ -1756,8 +1742,8 @@ export interface RemoveComments {
  * If this job produces an error or panic, please raise an [issue](https://github.com/noahbald/oxvg/issues)
  */
 export interface RemoveDeprecatedAttrs {
-  /** Whether to remove deprecated presentation attributes */
-  removeUnsafe: boolean
+  /** Whether to remove deprecated presentation attributes that may be unsafe to remove */
+  removeAny: boolean
 }
 
 /**
@@ -2355,16 +2341,12 @@ export type XMLNSOrder =
   | { type: 'Alphabetical' }
   | { type: 'Front' }
   | { type: 'Napi' }
-/** When running calculations against arcs, the level of error tolerated */
-export interface MakeArcs {
-  /** When calculating tolerance, controls the bound compared to error */
-  threshold: number
-  /** When calculating tolerance, controls the bound compared to the radius */
-  tolerance: number
+/** Tolerance for converting between SVG, Segments, and Polygons */
+export interface Tolerance {
+  /** The level of tolerance when comparing the error between distances */
+  positional: number
+  /** The level of tolerance when comparing the error between angles */
+  angular: number
+  /** The number of decimal places to round numbers to during processing */
+  precision: number
 }
-
-/** How many decimal points to round path command arguments */
-export type Precision =
-  | { type: 'None' }
-  | { type: 'Disabled' }
-  | { type: 'Enabled', field0: number }

--- a/packages/napi/test.js
+++ b/packages/napi/test.js
@@ -109,6 +109,56 @@ test("optimise with config", async () => {
 			};
 			assert.deepEqual(result, expected);
 		});
+
+		test("convertPathData", () => {
+			const result =convertSvgoConfig([
+				{
+					name: "convertPathData",
+					params: {
+		        applyTransforms: true,
+		        applyTransformsStroked: true,
+		        straightCurves: true,
+		        convertToQ: true,
+		        lineShorthands: true,
+		        convertToZ: true,
+		        curveSmoothShorthands: true,
+		        floatPrecision: 2,
+		        transformPrecision: 2,
+		        smartArcRounding: true,
+		        removeUseless: true,
+		        collapseRepeated: true,
+		        utilizeAbsolute: true,
+		        negativeExtraSpace: true,
+		        forceAbsolutePath: false	
+					}
+				}
+			]);
+			/** @type {import("./index.d.ts").Jobs} */
+			const expected = {
+				// Should apply when `applyTransforms: true`
+		    applyTransforms: {
+		      applyTransformsStroked: true,
+		      transformPrecision: 2
+		    },
+		    convertPathData: {
+		      arcCurves: false,
+		      closeSegments: true,
+		      joinNodes: true,
+		      removeCloseLine: true,
+		      removeEmptySegments: true,
+		      removeZeroSegments: true,
+		      smartArcRounding: true,
+		      straightCurves: true,
+		      tolerance: {
+		        angular: 0.001,
+		        positional: 0.001,
+		        precision: 2
+		      },
+		      uniteSegments: false
+		    }
+			};
+			assert.deepEqual(result, expected);
+		})
 	});
 });
 

--- a/packages/wasm/test.cjs
+++ b/packages/wasm/test.cjs
@@ -105,6 +105,56 @@ test("optimise with config", async () => {
 			};
 			assert.deepEqual(result, expected);
 		});
+
+		test("convertPathData", () => {
+			const result = convertSvgoConfig([
+				{
+					name: "convertPathData",
+					params: {
+		        applyTransforms: true,
+		        applyTransformsStroked: true,
+		        straightCurves: true,
+		        convertToQ: true,
+		        lineShorthands: true,
+		        convertToZ: true,
+		        curveSmoothShorthands: true,
+		        floatPrecision: 2,
+		        transformPrecision: 2,
+		        smartArcRounding: true,
+		        removeUseless: true,
+		        collapseRepeated: true,
+		        utilizeAbsolute: true,
+		        negativeExtraSpace: true,
+		        forceAbsolutePath: false	
+					}
+				},
+			]);
+			/** @type {import("./dist/node/oxvg_wasm.d.ts").Jobs} */
+			const expected = {
+				// Should apply when `applyTransforms: true`
+		    applyTransforms: {
+		      applyTransformsStroked: true,
+		      transformPrecision: 2
+		    },
+		    convertPathData: {
+		      arcCurves: false,
+		      closeSegments: true,
+		      joinNodes: true,
+		      removeCloseLine: true,
+		      removeEmptySegments: true,
+		      removeZeroSegments: true,
+		      smartArcRounding: true,
+		      straightCurves: true,
+		      tolerance: {
+		        angular: 0.001,
+		        positional: 0.001,
+		        precision: 2
+		      },
+		      uniteSegments: false
+		    }
+			};
+			assert.deepEqual(result, expected);
+		})
 	});
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Example: "feat(oxvg_ast): #123 add the feature" -->

## Description

This PR fixes failures to correctly convert SVGO config items.

Closes #236 

## Motivation and Context

Prevents unexpected changes in configuration when migrating from SVGO

## How Has This Been Tested?

Updated unit tests

## Types of changes
### Fixes

- Handle `ConvertPathData` options analagous to SVGO

### Breaking changes

- rename `RemoveDeprecatedAttrs::remove_unsafe` -> `RemoveDeprecatedAttrs::remove_any`
- rename `MinifyStyles::remove_unused` -> `MinifyStyles::usage`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
