### PR TITLE
fix: #244 remove "algorithm" as default oxvg_path feature

### DIFF
--- a/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
@@ -117,7 +117,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertPathData {
         let computed_styles = ComputedStyles::default()
             .with_all(element, &context.query_has_stylesheet_result)
             .map_err(JobsError::ComputedStylesError)?;
-        let (fill_rule, options) = gather_optimize_options(&computed_styles);
+        let (_, options) = gather_optimize_options(&computed_styles);
         let options = options & self.into();
         log::debug!("ConvertPathData::run: gained style info {options:?}");
 
@@ -130,7 +130,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertPathData {
             return Ok(());
         }
 
-        *path = path.optimize(options, fill_rule, &self.tolerance);
+        *path = path.optimize(options, &self.tolerance);
         Ok(())
     }
 }

--- a/crates/oxvg_optimiser/src/utils/style_info.rs
+++ b/crates/oxvg_optimiser/src/utils/style_info.rs
@@ -1,4 +1,3 @@
-use i_overlay::core::fill_rule::FillRule;
 use oxvg_ast::{
     get_computed_style,
     style::{ComputedStyles, Mode},
@@ -11,7 +10,9 @@ use lightningcss::{
     values::shape,
 };
 
-pub fn gather_optimize_options(computed_styles: &ComputedStyles) -> (FillRule, optimize::Options) {
+pub fn gather_optimize_options(
+    computed_styles: &ComputedStyles,
+) -> (shape::FillRule, optimize::Options) {
     let mut options = optimize::Options::all();
 
     let stroke = get_computed_style!(computed_styles, Stroke);
@@ -34,11 +35,11 @@ pub fn gather_optimize_options(computed_styles: &ComputedStyles) -> (FillRule, o
     let overlay_fill_rule = fill_rule
         .as_ref()
         .and_then(|(fill_rule, _)| match fill_rule {
-            Inheritable::Defined(shape::FillRule::Nonzero) => Some(FillRule::NonZero),
-            Inheritable::Defined(shape::FillRule::Evenodd) => Some(FillRule::EvenOdd),
-            _ => None,
+            Inheritable::Defined(fill_rule) => Some(fill_rule),
+            Inheritable::Inherited => None,
         })
-        .unwrap_or_default();
+        .copied()
+        .unwrap_or(shape::FillRule::Nonzero);
     let maybe_has_nonzero = fill_rule.as_ref().is_none_or(|(fill_rule, mode)| {
         *mode == Mode::Dynamic
             || matches!(

--- a/crates/oxvg_path/Cargo.toml
+++ b/crates/oxvg_path/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["algorithm", "geometry", "parse", "format", "optimise"]
+default = ["geometry", "parse", "format", "optimise"]
 algorithm = [
   "geometry",
   "dep:geo",
@@ -24,7 +24,7 @@ algorithm = [
   "dep:rstar",
 ]
 format = ["ryu", "itertools"]
-geometry = ["dep:geo-types"]
+geometry = ["dep:geo-types", "dep:geo", "dep:rstar"]
 jsonschema = ["schemars", "serde"]
 napi = ["dep:napi", "dep:napi-derive"]
 optimise = ["format", "bitflags"]

--- a/crates/oxvg_path/src/optimize.rs
+++ b/crates/oxvg_path/src/optimize.rs
@@ -1,7 +1,8 @@
 //! Methods for optimizing SVG paths
 
-use crate::{geometry::Tolerance, paths::segment, Path};
+use crate::{Path, geometry::Tolerance, paths::segment};
 
+#[cfg(feature = "algorithm")]
 pub use i_overlay::core::fill_rule::FillRule;
 
 bitflags! {
@@ -113,24 +114,30 @@ impl Path {
     ///
     /// ```
     /// use oxvg_path::Path;
-    /// use oxvg_path::optimize::{FillRule, Options};
+    /// use oxvg_path::optimize::{Options};
     /// use oxvg_path::geometry::Tolerance;
     /// use oxvg_path::parser::Parse as _;
     ///
     /// let mut path = Path::parse_string("M 10,30 L 10,50 L 30 30 H 10").unwrap();
     /// let options = Options::default();
     ///
-    /// path = path.optimize(options, FillRule::NonZero, &Tolerance::default());
+    /// path = path.optimize(options, &Tolerance::default());
     /// assert_eq!(&path.to_string(), "M10 30v20l20-20H10Z");
     /// ```
     #[must_use]
-    pub fn optimize(&self, options: Options, fill_rule: FillRule, tolerance: &Tolerance) -> Path {
+    pub fn optimize(
+        &self,
+        options: Options,
+        #[cfg(feature = "algorithm")] fill_rule: FillRule,
+        tolerance: &Tolerance,
+    ) -> Path {
         let mut segments = segment::Path::from_svg(self, tolerance);
 
         if options.contains(Options::CloseSegments) {
             segments.close_segments();
         }
 
+        #[cfg(feature = "algorithm")]
         if options.contains(Options::UniteSegments) {
             segments = segments.union_with_fill_rule(&segments, fill_rule);
         }


### PR DESCRIPTION
## Description

Basic packages shouldn't need features such as boolean operations on paths. Make this an opt-in feature instead.

## Motivation and Context

Boolean operations seem to rarely improve filesize and costs too much in runtime and binary size

## Types of changes

### Breaking changes

- Union optimise option is now inert unless "algorithm" feature is enabled
- Updated default features for oxvg_path

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
