### PR TITLE
feat: skia debug commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +173,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,7 +291,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -311,6 +346,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -441,6 +487,15 @@ name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -798,10 +853,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float_next_after"
@@ -1003,6 +1078,12 @@ dependencies = [
  "r-efi 6.0.0",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -1504,6 +1585,16 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -1623,6 +1714,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "napi"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,7 +1783,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -1690,6 +1797,16 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nonmax"
@@ -1957,6 +2074,7 @@ dependencies = [
  "clap",
  "etcetera",
  "ignore",
+ "itertools 0.15.0",
  "log",
  "ls-types",
  "oxvg_actions",
@@ -1969,11 +2087,13 @@ dependencies = [
  "roxmltree",
  "serde",
  "serde_json",
+ "skia-safe",
  "swc_core",
  "swc_ecma_lexer",
  "tokio",
  "tower-lsp-server",
  "typed-arena",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2457,6 +2577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +2654,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2919,6 +3055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3106,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -2970,6 +3121,12 @@ name = "sif-itree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -2988,6 +3145,47 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skia-bindings"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+dependencies = [
+ "bindgen",
+ "cc",
+ "flate2",
+ "heck",
+ "pkg-config",
+ "regex",
+ "serde_json",
+ "tar",
+ "toml",
+]
+
+[[package]]
+name = "skia-safe"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+dependencies = [
+ "base64",
+ "bitflags 2.13.1",
+ "percent-encoding",
+ "skia-bindings",
+ "skia-svg-macros",
+]
+
+[[package]]
+name = "skia-svg-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044dd2233c9717a74f75197f3e7f0a966db2127c0ffb5e05013b480a9b75b2c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "slab"
@@ -3397,6 +3595,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,6 +3757,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3938,6 +4186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,6 +4202,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xml5ever"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ tokio = "1.48"
 tower-lsp-server = "0.23"
 tsify = { version = "0.5", default-features = false, features = ["js"] }
 typed-arena = "2.0"
+urlencoding = "2.1"
 wasm-bindgen = "=0.2.104"
 web-sys = { version = "0.3" }
 xml5ever = "0.39"
@@ -119,6 +120,9 @@ strip = false
 lto = true
 
 [profile.release.package.oxvg_napi]
+strip = "symbols"
+
+[profile.release.package.oxvg_jsx_napi]
 strip = "symbols"
 
 [profile.release.package.oxvg_wasm]

--- a/crates/oxvg/Cargo.toml
+++ b/crates/oxvg/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/main.rs"
 test = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+visual-regression = ["dep:skia-safe"]
+render = ["dep:skia-safe"]
 
 [dependencies]
 oxvg_actions = { workspace = true }
@@ -37,11 +41,13 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 etcetera = "0.11"
 ignore = "0.4"
+itertools = { workspace = true }
 log = { workspace = true, features = ["release_max_level_off"] }
 ls-types = { workspace = true }
 roxmltree = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+skia-safe = { version = "0.99", optional = true, features = ["svg"] }
 swc_core = { workspace = true, features = [
   "ecma_ast",
   "ecma_codegen",
@@ -52,3 +58,4 @@ swc_ecma_lexer = { workspace = true }
 tokio = { workspace = true, features = ["io-std", "rt-multi-thread", "macros"] }
 tower-lsp-server = { workspace = true }
 typed-arena = { workspace = true }
+urlencoding = { workspace = true }

--- a/crates/oxvg/src/args.rs
+++ b/crates/oxvg/src/args.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use clap::{Parser, Subcommand};
 
 use crate::{
-    commands::{Action, Format, Lint, Optimise, JSX},
+    commands::{Action, Format, JSX, Lint, Optimise},
     config::Config,
 };
 
@@ -54,4 +54,10 @@ pub enum Command {
     Action(Action),
     /// Convert SVG documents to JSX
     JSX(JSX),
+    #[cfg(feature = "visual-regression")]
+    /// Visual regression testing for OXVG outputs
+    VisualRegression(crate::commands::VisualRegression),
+    #[cfg(feature = "render")]
+    /// Render SVG documents
+    Render(crate::commands::Render),
 }

--- a/crates/oxvg/src/commands.rs
+++ b/crates/oxvg/src/commands.rs
@@ -4,9 +4,17 @@ mod format;
 mod jsx;
 mod lint;
 mod optimise;
+#[cfg(feature = "render")]
+mod render;
+#[cfg(feature = "visual-regression")]
+mod visual_regression;
 
 pub use action::Action;
 pub use format::Format;
 pub use jsx::JSX;
 pub use lint::Lint;
 pub use optimise::Optimise;
+#[cfg(feature = "render")]
+pub use render::Render;
+#[cfg(feature = "visual-regression")]
+pub use visual_regression::VisualRegression;

--- a/crates/oxvg/src/commands/action.rs
+++ b/crates/oxvg/src/commands/action.rs
@@ -2,8 +2,8 @@ use std::{
     collections::HashSet,
     iter::Peekable,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -158,6 +158,7 @@ impl RunCommand for ActionRun {
                             input: path,
                             destination: output,
                             input_bytes: source.len() as f64,
+                            quiet: self.walk.quiet,
                         };
                         output.output()?;
                         Ok(())

--- a/crates/oxvg/src/commands/format.rs
+++ b/crates/oxvg/src/commands/format.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 use oxvg_ast::{
@@ -54,6 +54,7 @@ impl RunCommand for Format {
                             input: path,
                             destination: output,
                             input_bytes: source.len() as f64,
+                            quiet: self.walk.quiet,
                         };
                         output.output()?;
                         Ok(())

--- a/crates/oxvg/src/commands/optimise.rs
+++ b/crates/oxvg/src/commands/optimise.rs
@@ -92,6 +92,7 @@ impl Optimise {
                             input: path,
                             destination: output,
                             input_bytes,
+                            quiet: self.walk.quiet,
                         };
                         output.output()?;
                         Ok(())

--- a/crates/oxvg/src/commands/render.rs
+++ b/crates/oxvg/src/commands/render.rs
@@ -1,0 +1,109 @@
+use std::{
+    io::Write as _,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use skia_safe::{
+    AlphaType, Color, ColorType, FontMgr, IPoint, ISize, ImageInfo, Surface, surfaces,
+};
+
+use crate::{args::RunCommand, config::Config, walk::Walk};
+
+#[derive(clap::Args, Debug)]
+/// Render SVG documents.
+///
+/// Each SVG is rendered as an SVG and written to the output as a PNG.
+pub struct Render {
+    #[clap(flatten)]
+    /// Walk options
+    pub walk: Walk,
+}
+
+impl RunCommand for Render {
+    async fn run(self, _: Config) -> anyhow::Result<()> {
+        self.walk()
+    }
+}
+
+impl Render {
+    /// Sets up directory walker and uses it to run visual regression on each file.
+    ///
+    /// This should be ran with the same walk options as provided to the original command.
+    ///
+    /// # Errors
+    ///
+    /// When invalid options are given
+    pub fn walk(self) -> anyhow::Result<()> {
+        let error = Arc::new(AtomicBool::new(false));
+        self.walk.run(|| {
+            let error = Arc::clone(&error);
+            Box::new(move |source, path, output| {
+                let Some(output) = output.or(path) else {
+                    eprintln!("Rendering to stdout not supported");
+                    error.store(true, Ordering::Relaxed);
+                    return;
+                };
+                let mut output = output.clone();
+                output.set_extension("png");
+                let image = load_image(source).map_err(anyhow::Error::msg);
+                let data = image.and_then(|mut i| draw_svg(&mut i).map_err(anyhow::Error::msg));
+                let result = data.and_then(|d| {
+                    if let Some(parent) = output.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    let mut file = std::fs::File::create(output)?;
+                    file.write_all(&d)?;
+                    Ok(())
+                });
+                if let Err(err) = result {
+                    eprintln!("Error: {err}");
+                    error.store(true, Ordering::Relaxed);
+                }
+            })
+        })?;
+        if error.load(Ordering::Relaxed) {
+            Err(anyhow::anyhow!("Failed to format all documents!"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn rasterise(dom: &skia_safe::svg::Dom) -> anyhow::Result<(ISize, ImageInfo, Surface)> {
+    let size = dom.root().intrinsic_size().to_round();
+    let size = if size.width == 0 || size.height == 0 {
+        ISize::new(512, 512)
+    } else {
+        size
+    };
+    let info = ImageInfo::new(size, ColorType::RGBA8888, AlphaType::Premul, None);
+    let mut surface = surfaces::raster(&info, None, None)
+        .ok_or_else(|| anyhow::Error::msg("Failed to create surface"))?;
+    let canvas = surface.canvas();
+    canvas.clear(Color::TRANSPARENT);
+    dom.render(canvas);
+
+    Ok((size, info, surface))
+}
+
+fn load_image(svg: &str) -> anyhow::Result<(ISize, ImageInfo, Surface)> {
+    rasterise(&skia_safe::svg::Dom::from_str(svg, FontMgr::default())?)
+}
+
+#[allow(clippy::cast_sign_loss)]
+fn draw_svg((size, info, surface): &mut (ISize, ImageInfo, Surface)) -> anyhow::Result<Vec<u8>> {
+    let mut pixels = vec![0u8; (size.area() * 4) as usize];
+    if surface.read_pixels(
+        info,
+        &mut pixels,
+        (size.width * 4) as usize,
+        IPoint::new(0, 0),
+    ) {
+        Ok(pixels)
+    } else {
+        Err(anyhow::Error::msg("Failed to read pixels from surface"))
+    }
+}

--- a/crates/oxvg/src/commands/visual_regression.rs
+++ b/crates/oxvg/src/commands/visual_regression.rs
@@ -1,0 +1,205 @@
+use std::{io::Write as _, path::PathBuf};
+
+use itertools::Itertools as _;
+use skia_safe::{
+    AlphaType, Color, ColorType, EncodedImageFormat, FontMgr, IPoint, ISize, ImageInfo, Surface,
+    surfaces,
+};
+
+use crate::{args::RunCommand, config::Config, walk::Walk};
+
+const WIDTH: i32 = 512;
+const HEIGHT: i32 = 512;
+const MAX_DISTANCE: f64 = 510.0;
+
+/// The result of visually regression testing input and output SVG
+#[derive(Debug)]
+pub enum Status {
+    /// The output has visually regressed
+    Broken(f64),
+    /// The output is within threshold
+    Ok,
+}
+
+#[derive(clap::Args, Debug)]
+/// Visual regression testings.
+///
+/// Each SVG is rendered internally and visually compared to the original.
+///
+/// If the resulting SVG is visually regressed, it will an error will be emitted and screenshots
+/// written to `./screenshots/`.
+pub struct VisualRegression {
+    #[clap(flatten)]
+    /// Walk options
+    pub walk: Walk,
+}
+
+impl RunCommand for VisualRegression {
+    async fn run(self, _: Config) -> anyhow::Result<()> {
+        self.walk()
+    }
+}
+
+impl VisualRegression {
+    /// Sets up directory walker and uses it to run visual regression on each file.
+    ///
+    /// This should be ran with the same walk options as provided to the original command.
+    ///
+    /// # Errors
+    ///
+    /// When invalid options are given
+    pub fn walk(self) -> anyhow::Result<()> {
+        self.walk.run(move || {
+            Box::new(move |source, path, output| {
+                let Some(output) = output else {
+                    return;
+                };
+                let Ok(output) = std::fs::read_to_string(output) else {
+                    eprintln!("`{}` missing for visual-regression test", output.display());
+                    return;
+                };
+                if let Ok(Status::Broken(p)) = check(path, source, &output) {
+                    eprintln!(
+                        "\x1b[31mError: {}: visual regression detected by {p:.2}%.\x1b[0m",
+                        if let Some(path) = path {
+                            path.as_path().to_string_lossy()
+                        } else {
+                            std::borrow::Cow::Borrowed("document")
+                        }
+                    );
+                }
+            })
+        })
+    }
+}
+
+fn rasterise(
+    mut dom: skia_safe::svg::Dom,
+    resize: Option<ISize>,
+) -> anyhow::Result<(ISize, ImageInfo, Surface)> {
+    let scaled_size = resize.unwrap_or_else(|| ISize::new(WIDTH, HEIGHT));
+    dom.set_container_size(scaled_size);
+
+    let info = ImageInfo::new(scaled_size, ColorType::RGBA8888, AlphaType::Premul, None);
+    let mut surface = surfaces::raster(&info, None, None)
+        .ok_or_else(|| anyhow::Error::msg("Failed to create surface"))?;
+    let canvas = surface.canvas();
+    canvas.clear(Color::TRANSPARENT);
+    dom.render(canvas);
+
+    Ok((scaled_size, info, surface))
+}
+
+fn load_image(svg: &str, resize: Option<ISize>) -> anyhow::Result<(ISize, ImageInfo, Surface)> {
+    rasterise(
+        skia_safe::svg::Dom::from_str(svg, FontMgr::default())?,
+        resize,
+    )
+}
+
+#[allow(clippy::cast_sign_loss)]
+fn draw_svg((size, info, surface): &mut (ISize, ImageInfo, Surface)) -> anyhow::Result<Vec<u8>> {
+    let mut pixels = vec![0u8; (size.area() * 4) as usize];
+    if surface.read_pixels(
+        info,
+        &mut pixels,
+        (size.width * 4) as usize,
+        IPoint::new(0, 0),
+    ) {
+        Ok(pixels)
+    } else {
+        Err(anyhow::Error::msg("Failed to read pixels from surface"))
+    }
+}
+
+fn difference(left: (u8, u8, u8, u8), right: (u8, u8, u8, u8)) -> f64 {
+    if left == right {
+        0.0
+    } else {
+        let dr = right.0 as f64 - left.0 as f64;
+        let dg = right.1 as f64 - left.1 as f64;
+        let db = right.2 as f64 - left.2 as f64;
+        let da = right.3 as f64 - left.3 as f64;
+
+        (dr * dr + dg * dg + db * db + da * da).sqrt() / MAX_DISTANCE
+    }
+}
+
+#[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
+fn compare(original: Vec<u8>, optimised: Vec<u8>) -> Status {
+    assert_eq!(
+        original.len(),
+        optimised.len(),
+        "The optimised render should have been resized to match the original"
+    );
+    assert_eq!(
+        original.len() % 4,
+        0,
+        "image is not a quartet of RGBA values"
+    );
+
+    let len = original.len();
+    let errors = original
+        .into_iter()
+        .tuple_windows()
+        .zip(optimised.into_iter().tuple_windows())
+        .map(|(left, right)| difference(left, right))
+        .filter(|e| *e > 0.1)
+        .count();
+    let error_percentage = (errors as f64) / (len as f64);
+    if error_percentage > 0.02 {
+        Status::Broken(error_percentage * 100.0)
+    } else {
+        Status::Ok
+    }
+}
+
+/// Compares the input SVG to the parsed/processed SVG and returns whether it has visually regressed.
+///
+/// Writes a screenshot to `./screenshots/<path>.png` if the input path is given and has visually regressed.
+pub fn check(path: Option<&PathBuf>, original: &str, optimised: &str) -> anyhow::Result<Status> {
+    let mut original_image = load_image(original, None)?;
+    let mut optimised_image = load_image(optimised, Some(original_image.0))?;
+
+    let original = draw_svg(&mut original_image)?;
+    let optimised = draw_svg(&mut optimised_image)?;
+    let result = compare(original, optimised);
+    if matches!(result, Status::Broken(_))
+        && let Some(path) = path
+    {
+        let path_string = path.to_string_lossy();
+        let url_name = urlencoding::encode(&path_string);
+        if let Some(data) =
+            original_image
+                .2
+                .image_snapshot()
+                .encode(None, EncodedImageFormat::PNG, None)
+        {
+            let mut output_path = PathBuf::new();
+            output_path.push("screenshots");
+            std::fs::create_dir_all(&output_path).ok();
+            output_path.push(format!("{url_name}.input.png"));
+            output_path.set_extension("png");
+            let Ok(mut file) = std::fs::File::create(output_path) else {
+                return Ok(result);
+            };
+            file.write_all(data.as_bytes()).ok();
+        }
+        if let Some(data) =
+            optimised_image
+                .2
+                .image_snapshot()
+                .encode(None, EncodedImageFormat::PNG, None)
+        {
+            let mut output_path = PathBuf::new();
+            output_path.push("screenshots");
+            std::fs::create_dir_all(&output_path).ok();
+            output_path.push(format!("{url_name}.output.png"));
+            let Ok(mut file) = std::fs::File::create(output_path) else {
+                return Ok(result);
+            };
+            file.write_all(data.as_bytes()).ok();
+        }
+    }
+    Ok(result)
+}

--- a/crates/oxvg/src/main.rs
+++ b/crates/oxvg/src/main.rs
@@ -21,5 +21,9 @@ async fn main() -> anyhow::Result<()> {
         },
         Command::Action(args) => args.run(config).await,
         Command::JSX(args) => args.run(config).await,
+        #[cfg(feature = "visual-regression")]
+        Command::VisualRegression(args) => args.run(config).await,
+        #[cfg(feature = "render")]
+        Command::Render(args) => args.run(config).await,
     }
 }

--- a/crates/oxvg/src/walk.rs
+++ b/crates/oxvg/src/walk.rs
@@ -13,6 +13,7 @@ use oxvg_ast::{node::Ref, serialize::Node as _, xmlwriter::Options};
 type FnVisitor = Box<dyn FnMut(&str, Option<&PathBuf>, Option<&PathBuf>) + Send>;
 
 #[derive(clap::Args, Debug)]
+#[allow(clippy::struct_excessive_bools)]
 /// This will iterate over a set of paths.
 pub struct Walk {
     /// The set of paths to visit
@@ -43,6 +44,9 @@ pub struct Walk {
     /// Sets the approximate number of threads to use. A value of 0 (default) will automatically determine the appropriate number
     #[clap(long, short, default_value = "0")]
     pub threads: usize,
+    /// Supresses info logging
+    #[clap(long, default_value = "false")]
+    pub quiet: bool,
 }
 
 pub(crate) struct Output<'a, 'input, 'arena> {
@@ -51,6 +55,7 @@ pub(crate) struct Output<'a, 'input, 'arena> {
     pub input: Option<&'a PathBuf>,
     pub destination: Option<&'a PathBuf>,
     pub input_bytes: f64,
+    pub quiet: bool,
 }
 impl Output<'_, '_, '_> {
     #[allow(clippy::unnecessary_debug_formatting)]
@@ -74,9 +79,11 @@ impl Output<'_, '_, '_> {
                 let change = 100.0 * (input_kb - output_kb) / input_kb;
                 let increased = if change < 0.0 { "\x1b[31m" } else { "" };
                 let path = self.input.and_then(|p| p.to_str()).unwrap_or("");
-                println!(
-            "\n\n\x1b[32m{path:?} ({input_kb:.1}KB) -> {output:?} ({output_kb:.1}KB) {increased}({change:.2}%)\x1b[0m"
-                );
+                if !self.quiet {
+                    println!(
+                        "\n\n\x1b[32m{path:?} ({input_kb:.1}KB) -> {output:?} ({output_kb:.1}KB) {increased}({change:.2}%)\x1b[0m"
+                    );
+                }
             }
         } else {
             self.dom.serialize_into(std::io::stdout(), self.options)?;

--- a/crates/oxvg/src/walk.rs
+++ b/crates/oxvg/src/walk.rs
@@ -44,7 +44,7 @@ pub struct Walk {
     /// Sets the approximate number of threads to use. A value of 0 (default) will automatically determine the appropriate number
     #[clap(long, short, default_value = "0")]
     pub threads: usize,
-    /// Supresses info logging
+    /// Suppresses info logging
     #[clap(long, default_value = "false")]
     pub quiet: bool,
 }

--- a/crates/oxvg_optimiser/Cargo.toml
+++ b/crates/oxvg_optimiser/Cargo.toml
@@ -60,7 +60,7 @@ phf = { workspace = true }
 regex = { workspace = true }
 tsify = { workspace = true, optional = true }
 typed-arena = { workspace = true }
-urlencoding = "2.1"
+urlencoding = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }
 

--- a/packages/correctness/README.md
+++ b/packages/correctness/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]
+> This package is deprecated.
+>
+> Please compile OXVG with `-F visual-regression` and run `oxvg visual-regression` instead.
+> This package is preserved for now but may be removed at any point.
+
 This is a test suite to evaluate the correctness of OXVG's optimisation presets.
 
 Follows [svgcleaner's method](https://github.com/RazrFalcon/svgcleaner/blob/master/docs/testing_notes.rst)

--- a/packages/correctness/package.json
+++ b/packages/correctness/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.6",
 	"description": "",
 	"main": "index.js",
+	"deprecated": "use `oxvg visual-reression` command instead.",
 	"scripts": {
 		"test": "pnpm run optimise && pnpm run compare",
 		"optimise": "pnpm run optimise:w3c",


### PR DESCRIPTION
## Description

This PR adds `visual-regression` and `render` commands that use Skia to render/process SVGs.

## Motivation and Context
Previously we use `packages/correctness` to debug correctness issues with OXVG, however the `@napi-rs/canvas` library is prone to crashing, false positives, and is somewhat slow.

The `visual-regression` command re-implements this package directly into the OXVG library. It also adds a `render` command because it's just a simpler implementation of `visual-regression`, so why not.

Because `skia-safe` is a massive package it's put behind feature flags and should never be included in general releases. OXVG isn't intended to be used for rendering and more specialised programs such as `magick`, `resvg` or `sk` should be used for that.

## How Has This Been Tested?

Manually running the commands and going through the visual-regression screenshots.

## Types of changes

### Features

- Adds `visual-regression` command behind `-F visual-regression
- Adds `render` command behind `-F render`
- Adds `quiet` option for walk commands

## Checklist:
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [x] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [ ] All new and existing tests passed.
