### PR TITLE
fix(path): keep close command for real close edges

### DIFF
--- a/crates/oxvg_path/src/paths/segment/simplify.rs
+++ b/crates/oxvg_path/src/paths/segment/simplify.rs
@@ -368,9 +368,7 @@ impl Path {
                         .pop_if(|command| matches!(command, Data::LineTo(_)))
                         .is_some();
                 } else {
-                    // Line end outside of tolerance; segment must have
-                    // been coerced to `closed` in `Path::optimize`.
-                    segment.closed = false;
+                    // `Z` draws a real edge back to the start and must be kept.
                 }
             } else {
                 segment.closed = false;
@@ -391,6 +389,7 @@ mod test {
         geometry::Tolerance,
         geometry::{Arc, Curve, Point},
         optimize::Options,
+        parser::Parse as _,
         paths::segment::{Data, Path, Segment},
     };
 
@@ -500,5 +499,46 @@ mod test {
                 closed: true,
             }])
         );
+
+        let mut path = Path(vec![Segment {
+            start: Point::ZERO,
+            data: vec![Data::LineTo(Point::new(1.0, 0.0))],
+            closed: true,
+        }]);
+        path.simplify(Options::RemoveCloseLine, &Tolerance::default());
+        assert_eq!(
+            path,
+            Path(vec![Segment {
+                start: Point::ZERO,
+                data: vec![Data::LineTo(Point::new(1.0, 0.0))],
+                closed: true,
+            }])
+        );
+
+        let mut path = Path(vec![Segment {
+            start: Point::ZERO,
+            data: vec![
+                Data::LineTo(Point::new(1.0, 0.0)),
+                Data::LineTo(Point::new(1.0, 1.0)),
+            ],
+            closed: true,
+        }]);
+        path.simplify(Options::RemoveCloseLine, &Tolerance::default());
+        assert_eq!(
+            path,
+            Path(vec![Segment {
+                start: Point::ZERO,
+                data: vec![
+                    Data::LineTo(Point::new(1.0, 0.0)),
+                    Data::LineTo(Point::new(1.0, 1.0)),
+                ],
+                closed: true,
+            }])
+        );
+
+        let path = crate::Path::parse_string("M0 0L1 0Z")
+            .unwrap()
+            .optimize(Options::RemoveCloseLine, &Tolerance::default());
+        assert_eq!(path.to_string(), "M0 0h1Z");
     }
 }


### PR DESCRIPTION
`Options::RemoveCloseLine` opened closed subpaths when the retained final command did not return to the subpath start.

| Input | Before | After |
| --- | --- | --- |
| `M0 0L1 0Z` | `M0 0h1` | `M0 0h1Z` |
| `M0 0L1 0L1 1Z` | `M0 0h1v1` | `M0 0h1v1Z` |
| `M0 0L1 0L1 1L0 0Z` | `M0 0h1v1Z` | `M0 0h1v1Z` |

The triangle case is visible under stroke: opening the path drops the hypotenuse edge drawn by `Z`.

The root cause was an inverted coercion assumption in `remove_close_line`. The two coercion sites already land on the start before `RemoveCloseLine` runs: `Segment::from_svg` only coerces when the final endpoint is within tolerance, and `Path::close_segments` pushes an explicit `LineTo(segment.start)`. That means the else branch is reached by genuine `Z` commands whose close-line draws a real edge, so clearing `closed` there opened the path.

SVGO and `oxvg_path` 0.0.5 both keep the `Z` for these inputs.

Fixes #251