### PR TITLE
fix: #264 convert unparsed computed style to `Attr::CSSUnknown`

### DIFF
--- a/crates/oxvg_actions/src/actions/manipulate/path.rs
+++ b/crates/oxvg_actions/src/actions/manipulate/path.rs
@@ -92,11 +92,11 @@ impl<'input> Actor<'input, '_> {
                 .with_all(&path, &styles)
                 .map_err(|err| Error::ComputedStylesError(err.to_string()))?;
             let evenodd = get_computed_style!(computed_styles, FillRule)
-                .map(|fill_rule| match fill_rule {
+                .option()
+                .is_some_and(|fill_rule| match fill_rule {
                     (Inheritable::Defined(FillRule::Nonzero) | Inheritable::Inherited, _) => false,
                     (Inheritable::Defined(FillRule::Evenodd), _) => true,
-                })
-                .unwrap_or(false);
+                });
             let segment_path = oxvg_path::paths::bool::Path {
                 inner: segment_path,
                 evenodd,

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -30,6 +30,7 @@ macro_rules! get_computed_style {
             .and_then(|(attr, mode)| match attr {
                 oxvg_collections::attribute::Attr::$id(inner) => Some((inner, mode)),
                 oxvg_collections::attribute::Attr::Unparsed { .. } => None,
+                oxvg_collections::attribute::Attr::CSSUnknown { .. } => None,
                 _ => unreachable!("{attr:?}"),
             })
     };

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -25,14 +25,18 @@ use std::collections::HashMap;
 /// Returns the computed presentation attribute for a computed style in [`ComputedStyles`]
 macro_rules! get_computed_style {
     ($computed_style:expr, $id:ident$(,)?) => {
-        $computed_style
-            .get(&oxvg_collections::attribute::AttrId::$id)
-            .and_then(|(attr, mode)| match attr {
-                oxvg_collections::attribute::Attr::$id(inner) => Some((inner, mode)),
-                oxvg_collections::attribute::Attr::Unparsed { .. } => None,
-                oxvg_collections::attribute::Attr::CSSUnknown { .. } => None,
-                _ => unreachable!("{attr:?}"),
-            })
+        match $computed_style.get(&oxvg_collections::attribute::AttrId::$id) {
+            Some((oxvg_collections::attribute::Attr::$id(inner), mode)) => {
+                $crate::style::ComputedStyle::Some((inner, mode))
+            }
+            Some((
+                oxvg_collections::attribute::Attr::Unparsed { .. }
+                | oxvg_collections::attribute::Attr::CSSUnknown { .. },
+                _,
+            )) => $crate::style::ComputedStyle::Unparsed,
+            Some(attr) => unreachable!("{attr:?}"),
+            None => $crate::style::ComputedStyle::None,
+        }
     };
 }
 
@@ -58,6 +62,16 @@ macro_rules! get_computed_style_css {
     };
 }
 
+/// A computed style retrieved from an element.
+pub enum ComputedStyle<T> {
+    /// The computed style on the element along with the mode the style is set.
+    Some((T, Mode)),
+    /// The computed style exists but cannot be represented as an OXVG attribute.
+    Unparsed,
+    /// The computed style does not exist on the element.
+    None,
+}
+
 #[macro_export]
 /// Returns whether the computed presentation attribute exists for a computed style
 macro_rules! has_computed_style_css {
@@ -68,7 +82,7 @@ macro_rules! has_computed_style_css {
 }
 
 #[cfg(feature = "selectors")]
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 /// A mode in which a style can be applied to an element
 pub enum Mode {
     #[default]
@@ -121,6 +135,40 @@ pub fn root<'input, 'arena>(
     root.breadth_first()
         .filter_map(|node| node.first_child())
         .filter_map(|node| node.style().cloned())
+}
+
+impl<T> ComputedStyle<T> {
+    /// Returns a `ComputedStyle` with the inner value as a reference.
+    pub fn as_ref(&self) -> ComputedStyle<&T> {
+        match self {
+            Self::Some((inner, mode)) => ComputedStyle::Some((inner, *mode)),
+            Self::Unparsed => ComputedStyle::Unparsed,
+            Self::None => ComputedStyle::None,
+        }
+    }
+
+    /// Returns an option which is `Some` when the style could be parsed
+    pub fn parsed(self) -> Option<Option<(T, Mode)>> {
+        match self {
+            Self::Some(inner) => Some(Some(inner)),
+            Self::Unparsed => None,
+            Self::None => Some(None),
+        }
+    }
+
+    /// Returns an option which is `Some` when the style is present on the element
+    pub fn entry(self) -> Option<Option<(T, Mode)>> {
+        match self {
+            Self::Some(inner) => Some(Some(inner)),
+            Self::Unparsed => Some(None),
+            Self::None => None,
+        }
+    }
+
+    /// Returns `Some` only when the computed style is present and could be parsed
+    pub fn option(self) -> Option<(T, Mode)> {
+        self.parsed().flatten()
+    }
 }
 
 #[cfg(feature = "selectors")]
@@ -211,7 +259,7 @@ impl<'input> ComputedStyles<'input> {
     ) -> Result<ComputedStyles<'input>, ComputedStylesError<'input>> {
         for css in styles {
             for s in &css.borrow().0 {
-                self.with_nested_style(element, s, &mut Vec::new(), 0, &Mode::Static)?;
+                self.with_nested_style(element, s, &mut Vec::new(), 0, Mode::Static)?;
             }
         }
         Ok(self)
@@ -224,7 +272,7 @@ impl<'input> ComputedStyles<'input> {
         style: &rules::CssRule<'input>,
         selector: &mut Vec<String>,
         specificity: u32,
-        #[allow(unused_variables)] mode: &Mode,
+        #[allow(unused_variables)] mode: Mode,
     ) -> Result<(), ComputedStylesError<'input>> {
         use crate::selectors::{SelectElement, Selector};
         use lightningcss::{printer::PrinterOptions, traits::ToCss};
@@ -256,7 +304,7 @@ impl<'input> ComputedStyles<'input> {
             rules::CssRule::Container(rules::container::ContainerRule { rules, .. })
             | rules::CssRule::Media(rules::media::MediaRule { rules, .. }) => {
                 for r in &rules.0 {
-                    self.with_nested_style(element, r, selector, specificity, &Mode::Dynamic)?;
+                    self.with_nested_style(element, r, selector, specificity, Mode::Dynamic)?;
                 }
                 Ok(())
             }
@@ -435,7 +483,7 @@ impl<'input> ComputedStyles<'input> {
         &mut self,
         declarations: &lightningcss::declaration::DeclarationBlock<'input>,
         specificity: u32,
-        mode: &Mode,
+        mode: Mode,
     ) {
         Self::set_declarations(
             &mut self.important_declarations,
@@ -455,7 +503,7 @@ impl<'input> ComputedStyles<'input> {
         record: &mut HashMap<PropertyId<'input>, (u32, Style<'input>)>,
         declarations: &[lightningcss::properties::Property<'input>],
         specificity: u32,
-        mode: &Mode,
+        mode: Mode,
     ) {
         for d in declarations {
             let id = d.property_id();
@@ -468,7 +516,7 @@ impl<'input> ComputedStyles<'input> {
 impl Mode {
     /// # Panics
     /// If attempting to assign attribute to dynamic style
-    fn style<'i>(&self, style: Static<'i>) -> Style<'i> {
+    fn style(self, style: Static<'_>) -> Style<'_> {
         match self {
             Self::Static => Style::Static(style),
             Self::Dynamic => match style {

--- a/crates/oxvg_collections/src/attribute.rs
+++ b/crates/oxvg_collections/src/attribute.rs
@@ -20,9 +20,9 @@ use inheritable::Inheritable;
 use lightningcss::{
     media_query::{MediaList, MediaQuery},
     properties::{
+        Property, PropertyId,
         font::{AbsoluteFontSize, AbsoluteFontWeight, FontStretchKeyword},
         ui::CursorKeyword,
-        Property, PropertyId,
     },
     values::{
         alpha::AlphaValue,
@@ -2613,7 +2613,7 @@ macro_rules! try_from_into_property {
 
             fn try_from(value: Property<'input>) -> Result<Self, Self::Error> {
                 use lightningcss::properties::custom::{
-                    CustomProperty, CustomPropertyName
+                    CustomProperty, CustomPropertyName, UnparsedProperty,
                 };
                 Ok(match value {
                     $(Property::$name($value$(, $vp)?) $(if $vp == VendorPrefix::None)? => {
@@ -2627,6 +2627,13 @@ macro_rules! try_from_into_property {
                             prefix: Prefix::SVG,
                             local: name.0.into(),
                         }),
+                        value: TokenList(value),
+                    },
+                    Property::Unparsed(UnparsedProperty {
+                        property_id,
+                        value
+                    }) => Attr::CSSUnknown {
+                        attr_id: (&property_id).try_into()?,
                         value: TokenList(value),
                     },
                     _ => return Err(())

--- a/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
+++ b/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
@@ -9,16 +9,16 @@ use oxvg_ast::{
     element::Element,
     get_attribute, get_attribute_mut, get_computed_style, get_computed_style_css, has_attribute,
     is_attribute,
-    style::{ComputedStyles, Mode},
+    style::{ComputedStyle, ComputedStyles, Mode},
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::{
+    Attr, AttrId,
     core_attrs::SVGTransformList,
     inheritable::Inheritable,
     presentation::{LengthPercentage, VectorEffect},
-    Attr, AttrId,
 };
-use oxvg_path::{command::Data, Path};
+use oxvg_path::{Path, command::Data};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -129,23 +129,29 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ApplyTransforms {
                 .is_none_or(|css_transform: SVGTransformList| {
                     transform.to_matrix_2d() != css_transform.to_matrix_2d()
                 })
-            {
-                log::debug!("run: another transform is applied to this element");
-                return Ok(());
-            }
+        {
+            log::debug!("run: another transform is applied to this element");
+            return Ok(());
+        }
 
         let stroke = get_computed_style!(computed_styles, Stroke);
-        if matches!(stroke, Some((_, Mode::Dynamic))) {
+        if matches!(
+            stroke,
+            ComputedStyle::Some((_, Mode::Dynamic)) | ComputedStyle::Unparsed
+        ) {
             log::debug!("run: cannot handle dynamic stroke");
             return Ok(());
         }
 
         let stroke_width = get_computed_style!(computed_styles, StrokeWidth);
-        if matches!(stroke_width, Some((_, Mode::Dynamic))) {
+        if matches!(
+            stroke_width,
+            ComputedStyle::Some((_, Mode::Dynamic)) | ComputedStyle::Unparsed
+        ) {
             log::debug!("run: cannot handle dynamic stroke_width");
             return Ok(());
         }
-        let stroke_width = stroke_width.map(|(stroke_width, _)| stroke_width);
+        let stroke_width = stroke_width.option().map(|(stroke_width, _)| stroke_width);
 
         let css_transform: TransformList = transform.clone().into();
         let Some(matrix) = css_transform.to_matrix() else {
@@ -159,10 +165,11 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ApplyTransforms {
         let matrix = matrix32_to_slice(&matrix);
 
         drop(transform_attr);
-        if let Some((Inheritable::Defined(stroke), Mode::Static)) = stroke
-            && self.apply_stroked(&matrix, &stroke, stroke_width, element) {
-                return Ok(());
-            }
+        if let Some((Inheritable::Defined(stroke), Mode::Static)) = stroke.option()
+            && self.apply_stroked(&matrix, &stroke, stroke_width, element)
+        {
+            return Ok(());
+        }
 
         let Some(mut d) = get_attribute_mut!(element, D) else {
             unreachable!();
@@ -200,9 +207,10 @@ impl ApplyTransforms {
         }
 
         if let Some(vector_effect) = get_attribute!(element, VectorEffect)
-            && matches!(&*vector_effect, VectorEffect::NonScalingStroke) {
-                return false;
-            }
+            && matches!(&*vector_effect, VectorEffect::NonScalingStroke)
+        {
+            return false;
+        }
 
         let mut scale = f64::sqrt((matrix[0] * matrix[0]) + (matrix[1] * matrix[1])); // hypot
         if let Some(transform_precision) = self.transform_precision {
@@ -254,9 +262,10 @@ fn apply_matrix_to_path_data(path_data: &mut Path, matrix: &[f64; 6]) {
     let mut start = [0.0; 2];
     let mut cursor = [0.0; 2];
     if let Some(data) = path_data.0.get_mut(0)
-        && let Data::MoveBy(args) = data {
-            *data = Data::MoveTo(*args);
-        }
+        && let Data::MoveBy(args) = data
+    {
+        *data = Data::MoveTo(*args);
+    }
 
     path_data.0.iter_mut().for_each(|data| {
         if let Data::Implicit(_) = data {

--- a/crates/oxvg_optimiser/src/jobs/merge_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_paths.rs
@@ -119,15 +119,17 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MergePaths {
                 continue;
             };
             if let Some(first) = current_path_data.0.first_mut()
-                && let command::Data::MoveBy(data) = first {
-                    *first = command::Data::MoveTo(*data);
+                && let command::Data::MoveBy(data) = first
+            {
+                *first = command::Data::MoveTo(*data);
 
-                    if let Some(second) = current_path_data.0.get_mut(1)
-                        && second.is_implicit() && second.as_explicit().id() != command::ID::LineTo
-                        {
-                            *second = second.as_explicit().clone();
-                        }
+                if let Some(second) = current_path_data.0.get_mut(1)
+                    && second.is_implicit()
+                    && second.as_explicit().id() != command::ID::LineTo
+                {
+                    *second = second.as_explicit().clone();
                 }
+            }
             drop(current_path_data);
 
             if
@@ -136,15 +138,15 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MergePaths {
                     MarkerStart | MarkerMid | MarkerEnd | ClipPath | Mask
                 )
                 || has_computed_style_css!(computed_styles, MaskImage(None))
-                || get_computed_style!(computed_styles, Fill).is_some_and(|(fill, mode)| {
+                || get_computed_style!(computed_styles, Fill).option().is_some_and(|(fill, mode)| {
                     matches!(mode, Mode::Static)
                         && matches!(fill.option(), Some(SVGPaint::Url { url,.. }) if url.url.starts_with('#'))
                 })
-                || get_computed_style!(computed_styles, Filter).is_some_and(|(filter, mode)| {
+                || get_computed_style!(computed_styles, Filter).option().is_some_and(|(filter, mode)| {
                     matches!(mode, Mode::Static)
                         && matches!(filter, Inheritable::Defined(FilterList::Filters(filters)) if filters.iter().any(|filter| matches!(filter, Filter::Url(url) if url.url.starts_with('#'))))
                 })
-                || get_computed_style!(computed_styles, Stroke).is_some_and(|(stroke, mode)| {
+                || get_computed_style!(computed_styles, Stroke).option().is_some_and(|(stroke, mode)| {
                     matches!(mode, Mode::Static) && matches!(stroke.option(), Some(SVGPaint::Url { url,.. }) if url.url.starts_with('#'))
                 })
             {

--- a/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
@@ -16,8 +16,8 @@ use oxvg_ast::{
 use oxvg_collections::{
     atom::Atom,
     attribute::{
-        core_attrs::NonWhitespace, inheritable::Inheritable, presentation::LengthPercentage,
-        uncategorised::Radius, Attr,
+        Attr, core_attrs::NonWhitespace, inheritable::Inheritable, presentation::LengthPercentage,
+        uncategorised::Radius,
     },
     element::{ElementId, ElementInfo},
 };
@@ -145,7 +145,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Data<'input, 'arena> {
             .map_err(JobsError::ComputedStylesError)?;
         if self.opacity_zero
             && matches!(
-                get_computed_style!(computed_styles, Opacity),
+                get_computed_style!(computed_styles, Opacity).option(),
                 Some((Inheritable::Defined(AlphaValue(0.0)), Mode::Static))
             )
         {
@@ -165,16 +165,17 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Data<'input, 'arena> {
 impl<'input, 'arena> Data<'input, 'arena> {
     fn remove_element(&self, element: &Element<'input, 'arena>) {
         if let Some(parent) = Element::parent_element(element)
-            && is_element!(parent, Defs) {
-                if let Some(NonWhitespace(id)) = get_attribute!(element, Id).as_deref() {
-                    self.removed_def_ids.borrow_mut().insert(id.clone());
-                }
-                if parent.child_element_count() == 1 {
-                    log::debug!("data: removing parent");
-                    parent.remove();
-                    return;
-                }
+            && is_element!(parent, Defs)
+        {
+            if let Some(NonWhitespace(id)) = get_attribute!(element, Id).as_deref() {
+                self.removed_def_ids.borrow_mut().insert(id.clone());
             }
+            if parent.child_element_count() == 1 {
+                log::debug!("data: removing parent");
+                parent.remove();
+                return;
+            }
+        }
         log::debug!("data: removing element: {element:?}");
         element.remove();
     }
@@ -325,9 +326,10 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 impl<'input, 'arena> State<'_, 'input, 'arena> {
     fn can_remove_non_rendering_node(&self, element: &Element<'input, 'arena>) -> bool {
         if let Some(id) = get_attribute!(element, Id)
-            && self.data.all_references.borrow().contains(&**id) {
-                return false;
-            }
+            && self.data.all_references.borrow().contains(&**id)
+        {
+            return false;
+        }
         element
             .children_iter()
             .all(|e| self.can_remove_non_rendering_node(&e))
@@ -342,35 +344,39 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
         let mut is_hidden = false;
         if self.options.is_hidden.unwrap_or(true)
             && let Some((Inheritable::Defined(Visibility::Hidden), Mode::Static)) =
-                get_computed_style!(computed_styles, Visibility)
-                && !element.breadth_first().any(|child| {
-                    matches!(
-                        get_attribute!(child, Visibility).as_deref(),
-                        Some(Inheritable::Defined(Visibility::Visible) | Inheritable::Inherited)
-                    )
-                }) {
-                    is_hidden = true;
-                }
+                get_computed_style!(computed_styles, Visibility).option()
+            && !element.breadth_first().any(|child| {
+                matches!(
+                    get_attribute!(child, Visibility).as_deref(),
+                    Some(Inheritable::Defined(Visibility::Visible) | Inheritable::Inherited)
+                )
+            })
+        {
+            is_hidden = true;
+        }
 
-        if !is_hidden && self.options.display_none.unwrap_or(true)
+        if !is_hidden
+            && self.options.display_none.unwrap_or(true)
             && let Some((Inheritable::Defined(Display::Keyword(DisplayKeyword::None)), _)) =
-                get_computed_style!(computed_styles, Display)
-            {
-                is_hidden = !is_element!(element, Marker);
-            }
+                get_computed_style!(computed_styles, Display).option()
+        {
+            is_hidden = !is_element!(element, Marker);
+        }
         if is_hidden {
             // Protect references that may use non-visible data
             let references_by_id = self.data.references_by_id.borrow();
             if let Some(id) = get_attribute!(element, Id)
-                && references_by_id.contains_key(id.0.as_str()) {
-                    context.flags.visit_skip();
-                    return false;
-                }
+                && references_by_id.contains_key(id.0.as_str())
+            {
+                context.flags.visit_skip();
+                return false;
+            }
             return !element.breadth_first().any(|child| {
                 if let Some(id) = get_attribute!(child, Id)
-                    && references_by_id.contains_key(id.0.as_str()) {
-                        return true;
-                    }
+                    && references_by_id.contains_key(id.0.as_str())
+                {
+                    return true;
+                }
                 false
             });
         }
@@ -383,28 +389,31 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
             && self.options.circle_r_zero.unwrap_or(true)
             && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
                 get_attribute!(element, RGeometry).as_deref()
-                && length.to_px() == Some(0.0) {
-                    log::debug!("RemoveHiddenElement: removing hidden ellipse");
-                    element.remove();
-                    return true;
-                }
+            && length.to_px() == Some(0.0)
+        {
+            log::debug!("RemoveHiddenElement: removing hidden ellipse");
+            element.remove();
+            return true;
+        }
 
         if is_element!(element, Ellipse) {
             if self.options.ellipse_rx_zero.unwrap_or(true)
                 && let Some(Radius::LengthPercentage(LengthPercentage(
                     DimensionPercentage::Dimension(length),
                 ))) = get_attribute!(element, RX).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
 
             if self.options.ellipse_ry_zero.unwrap_or(true)
                 && let Some(Radius::LengthPercentage(LengthPercentage(
                     DimensionPercentage::Dimension(length),
                 ))) = get_attribute!(element, RY).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
         }
 
         false
@@ -415,15 +424,17 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
             if self.options.rect_width_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
                     get_attribute!(element, WidthRect).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
             if self.options.rect_height_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
                     get_attribute!(element, HeightRect).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
         }
         false
     }
@@ -433,15 +444,17 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
             if self.options.pattern_width_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
                     get_attribute!(element, WidthPattern).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
             if self.options.pattern_height_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
                     get_attribute!(element, HeightPattern).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
         }
         false
     }
@@ -451,15 +464,17 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
             if self.options.image_width_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
                     get_attribute!(element, WidthImage).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
             if self.options.image_height_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
                     get_attribute!(element, HeightImage).as_deref()
-                    && length.to_px() == Some(0.0) {
-                        return true;
-                    }
+                && length.to_px() == Some(0.0)
+            {
+                return true;
+            }
         }
         false
     }
@@ -473,8 +488,8 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
             let Some(d) = get_attribute!(element, D) else {
                 return true;
             };
-            return d.0 .0.is_empty()
-                || (d.0 .0.len() == 1
+            return d.0.0.is_empty()
+                || (d.0.0.len() == 1
                     && !has_computed_style!(computed_styles, MarkerStart)
                     && !has_computed_style!(computed_styles, MarkerEnd));
         }

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -8,7 +8,7 @@ use oxvg_ast::{
     visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
 };
 use oxvg_collections::{
-    attribute::{inheritable::Inheritable, AttrId},
+    attribute::{AttrId, inheritable::Inheritable},
     element::ElementCategory,
     is_prefix,
 };
@@ -197,12 +197,12 @@ impl State<'_> {
 
             if let Some((parent_stroke, mode)) = computed_styles.get_inherited("stroke")
                 && matches!(mode, Mode::Static)
-                    && !is_attribute!(parent_stroke, Stroke(Inheritable::Defined(SVGPaint::None)))
-                {
-                    log::debug!("stroke is also inherited, setting to `none`");
-                    set_attribute!(element, Stroke(Inheritable::Defined(SVGPaint::None)));
-                    is_stroke_eq_none = true;
-                }
+                && !is_attribute!(parent_stroke, Stroke(Inheritable::Defined(SVGPaint::None)))
+            {
+                log::debug!("stroke is also inherited, setting to `none`");
+                set_attribute!(element, Stroke(Inheritable::Defined(SVGPaint::None)));
+                is_stroke_eq_none = true;
+            }
         }
 
         if is_stroke_eq_none && self.options.remove_none {

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -145,7 +145,7 @@ impl State<'_> {
         }
 
         let stroke_width = get_computed_style!(computed_styles, StrokeWidth);
-        let is_stroke_width_zero = stroke_width.is_some_and(|(stroke_width, mode)| {
+        let is_stroke_width_zero = stroke_width.option().is_some_and(|(stroke_width, mode)| {
             if matches!(mode, Mode::Dynamic) {
                 return false;
             }
@@ -164,18 +164,23 @@ impl State<'_> {
         let stroke = get_computed_style!(computed_styles, Stroke);
         let mut is_stroke_eq_none = stroke
             .as_ref()
+            .option()
             .is_some_and(|(stroke, _)| matches!(stroke.option_ref(), Some(SVGPaint::None)));
-        let is_stroke_none =
-            stroke.is_none_or(|(_, mode)| matches!(mode, Mode::Static) && is_stroke_eq_none);
+        let is_stroke_none = stroke
+            .entry()
+            .is_none_or(|stroke| matches!(stroke, Some((_, Mode::Static))) && is_stroke_eq_none);
 
         let stroke_opacity = get_computed_style!(computed_styles, StrokeOpacity);
-        let is_stroke_opacity_zero = stroke_opacity.is_some_and(|(stroke_opacity, mode)| {
-            matches!(mode, Mode::Static)
-                && matches!(stroke_opacity, Inheritable::Defined(AlphaValue(0.0)))
-        });
+        let is_stroke_opacity_zero =
+            stroke_opacity
+                .option()
+                .is_some_and(|(stroke_opacity, mode)| {
+                    matches!(mode, Mode::Static)
+                        && matches!(stroke_opacity, Inheritable::Defined(AlphaValue(0.0)))
+                });
 
         let stroke_width = get_computed_style!(computed_styles, StrokeWidth);
-        let is_stroke_width_zero = stroke_width.is_some_and(|(stroke_width, mode)| {
+        let is_stroke_width_zero = stroke_width.option().is_some_and(|(stroke_width, mode)| {
             if matches!(mode, Mode::Dynamic) {
                 return false;
             }
@@ -221,15 +226,17 @@ impl State<'_> {
         }
 
         let fill = get_computed_style!(computed_styles, Fill);
-        let mut is_fill_eq_none = fill.as_ref().is_some_and(|fill| {
+        let mut is_fill_eq_none = fill.as_ref().option().is_some_and(|fill| {
             matches!(fill, (Inheritable::Defined(SVGPaint::None), Mode::Static))
         });
         let is_fill_none = fill
             .as_ref()
+            .option()
             .is_some_and(|(_, mode)| matches!(mode, Mode::Static) && is_fill_eq_none);
 
         let fill_opacity = get_computed_style!(computed_styles, FillOpacity);
         let is_fill_opacity_zero = fill_opacity
+            .option()
             .is_some_and(|s| matches!(s, (Inheritable::Defined(AlphaValue(0.0)), Mode::Static)));
 
         if is_fill_none || is_fill_opacity_zero {
@@ -240,7 +247,7 @@ impl State<'_> {
                 .attributes()
                 .retain(|attr| !is_prefix!(attr, SVG) || !attr.local_name().starts_with("fill-"));
 
-            if fill.is_none() || !is_fill_eq_none {
+            if fill.entry().is_none() || !is_fill_eq_none {
                 set_attribute!(element, Fill(Inheritable::Defined(SVGPaint::None)));
                 is_fill_eq_none = true;
             }

--- a/crates/oxvg_optimiser/src/utils/style_info.rs
+++ b/crates/oxvg_optimiser/src/utils/style_info.rs
@@ -10,6 +10,7 @@ use lightningcss::{
     values::shape,
 };
 
+#[allow(clippy::too_many_lines)]
 pub fn gather_optimize_options(
     computed_styles: &ComputedStyles,
 ) -> (shape::FillRule, optimize::Options) {
@@ -18,75 +19,99 @@ pub fn gather_optimize_options(
     let stroke = get_computed_style!(computed_styles, Stroke);
     let linecap = get_computed_style!(computed_styles, StrokeLinecap);
     let linejoin = get_computed_style!(computed_styles, StrokeLinejoin);
-    let maybe_has_stroke = stroke.is_some_and(|(stroke, mode)| {
-        mode == Mode::Dynamic || !matches!(stroke.option(), Some(SVGPaint::None))
+    let maybe_has_stroke = stroke.entry().is_some_and(|stroke| {
+        stroke.is_none_or(|(stroke, mode)| {
+            mode == Mode::Dynamic || !matches!(stroke.option(), Some(SVGPaint::None))
+        })
     });
-    let maybe_has_linecap = linecap.as_ref().is_some_and(|(linecap, mode)| {
-        *mode == Mode::Static && !matches!(linecap, Inheritable::Defined(StrokeLinecap::Butt))
+    let maybe_has_linecap = linecap.as_ref().entry().is_some_and(|linecap| {
+        linecap.is_none_or(|(linecap, mode)| {
+            mode == Mode::Static && !matches!(linecap, Inheritable::Defined(StrokeLinecap::Butt))
+        })
     });
     let safe_to_close = !maybe_has_stroke
-        || (linecap.is_some_and(|(linecap, mode)| {
+        || (linecap.option().is_some_and(|(linecap, mode)| {
             mode == Mode::Static && matches!(linecap, Inheritable::Defined(StrokeLinecap::Round))
-        }) && linejoin.is_some_and(|(linejoin, mode)| {
+        }) && linejoin.option().is_some_and(|(linejoin, mode)| {
             mode == Mode::Static && matches!(linejoin, Inheritable::Defined(StrokeLinejoin::Round))
         }));
 
     let fill_rule = get_computed_style!(computed_styles, FillRule);
     let overlay_fill_rule = fill_rule
         .as_ref()
+        .option()
         .and_then(|(fill_rule, _)| match fill_rule {
             Inheritable::Defined(fill_rule) => Some(fill_rule),
             Inheritable::Inherited => None,
         })
         .copied()
         .unwrap_or(shape::FillRule::Nonzero);
-    let maybe_has_nonzero = fill_rule.as_ref().is_none_or(|(fill_rule, mode)| {
-        *mode == Mode::Dynamic
-            || matches!(
-                fill_rule,
-                Inheritable::Defined(shape::FillRule::Nonzero) | Inheritable::Inherited
-            )
+    let maybe_has_nonzero = fill_rule.as_ref().entry().is_none_or(|fill_rule| {
+        fill_rule.is_none_or(|(fill_rule, mode)| {
+            mode == Mode::Dynamic
+                || matches!(
+                    fill_rule,
+                    Inheritable::Defined(shape::FillRule::Nonzero) | Inheritable::Inherited
+                )
+        })
     });
-    let maybe_has_evenodd = fill_rule.as_ref().is_some_and(|(fill_rule, mode)| {
-        *mode == Mode::Dynamic
-            || matches!(
-                fill_rule,
-                Inheritable::Defined(shape::FillRule::Evenodd) | Inheritable::Inherited
-            )
+    let maybe_has_evenodd = fill_rule.as_ref().entry().is_some_and(|fill_rule| {
+        fill_rule.is_none_or(|(fill_rule, mode)| {
+            mode == Mode::Dynamic
+                || matches!(
+                    fill_rule,
+                    Inheritable::Defined(shape::FillRule::Evenodd) | Inheritable::Inherited
+                )
+        })
     });
 
-    let maybe_has_marker =
-        get_computed_style!(computed_styles, Marker).is_some_and(|(marker, mode)| {
-            mode == Mode::Dynamic
-                || matches!(
-                    marker,
-                    Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
-                )
+    let maybe_has_marker = get_computed_style!(computed_styles, Marker)
+        .entry()
+        .is_some_and(|marker| {
+            marker.is_none_or(|(marker, mode)| {
+                mode == Mode::Dynamic
+                    || matches!(
+                        marker,
+                        Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
+                    )
+            })
         });
     let maybe_has_marker_start = maybe_has_marker
-        || get_computed_style!(computed_styles, MarkerStart).is_some_and(|(marker, mode)| {
-            mode == Mode::Dynamic
-                || matches!(
-                    marker,
-                    Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
-                )
-        });
+        || get_computed_style!(computed_styles, MarkerStart)
+            .entry()
+            .is_some_and(|marker| {
+                marker.is_none_or(|(marker, mode)| {
+                    mode == Mode::Dynamic
+                        || matches!(
+                            marker,
+                            Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
+                        )
+                })
+            });
     let maybe_has_marker_mid = maybe_has_marker
-        || get_computed_style!(computed_styles, MarkerMid).is_some_and(|(marker, mode)| {
-            mode == Mode::Dynamic
-                || matches!(
-                    marker,
-                    Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
-                )
-        });
+        || get_computed_style!(computed_styles, MarkerMid)
+            .entry()
+            .is_some_and(|marker| {
+                marker.is_none_or(|(marker, mode)| {
+                    mode == Mode::Dynamic
+                        || matches!(
+                            marker,
+                            Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
+                        )
+                })
+            });
     let maybe_has_marker_end = maybe_has_marker
-        || get_computed_style!(computed_styles, MarkerEnd).is_some_and(|(marker, mode)| {
-            mode == Mode::Dynamic
-                || matches!(
-                    marker,
-                    Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
-                )
-        });
+        || get_computed_style!(computed_styles, MarkerEnd)
+            .entry()
+            .is_some_and(|marker| {
+                marker.is_none_or(|(marker, mode)| {
+                    mode == Mode::Dynamic
+                        || matches!(
+                            marker,
+                            Inheritable::Inherited | Inheritable::Defined(Marker::Url(_))
+                        )
+                })
+            });
     let maybe_has_any_marker =
         maybe_has_marker_start || maybe_has_marker_mid || maybe_has_marker_end;
 
@@ -108,7 +133,8 @@ pub fn gather_optimize_options(
         | optimize::Options::from_bits_retain((!maybe_has_marker_end as u16) * u16::MAX);
     options &= !optimize::Options::UniteSegments
         | optimize::Options::from_bits_retain(
-            ((fill_rule.is_none() || (maybe_has_evenodd ^ maybe_has_nonzero)) as u16) * u16::MAX,
+            ((fill_rule.entry().is_none() || (maybe_has_evenodd ^ maybe_has_nonzero)) as u16)
+                * u16::MAX,
         );
     options.set(
         optimize::Options::RemoveCloseLine,


### PR DESCRIPTION
## Description

This fixes a panic when using a stylesheet that has properties lightningcss is unable to parse.

Closes #264 #239 

## How Has This Been Tested?

- `'<svg><p d="M0 0l0 1" style="fill: var(--c, #fff)"/></svg>' | oxvg optimise`

Note that OXVG assumes unparseable properties are invalid, and so drops them.

## Types of changes
### Fixes

- `TryFrom<Property> for Attr` handles `Property::UnparsedProperty`
- `get_computed_style!` returns a new type `ComputedStyle` with `Unparsed` variant

## Checklist:
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
