### PR TITLE
feat: #231 implement insert action

### DIFF
--- a/crates/oxvg/src/commands/action.rs
+++ b/crates/oxvg/src/commands/action.rs
@@ -233,6 +233,10 @@ impl RunCommand for ActionList {
             println!("# Skew Y\n");
             println!(include_str!("../spec/manipulate/skewY.md"));
         }
+        if parts.is_empty() || parts.contains(INSERT) || parts.contains(CREATE_ELEMENT) {
+            println!("# Insert\n");
+            println!(include_str!("../spec/structure/insert.md"));
+        }
         if parts.is_empty() || parts.contains(FORGET) {
             println!("# Forget\n");
             println!(include_str!("../spec/state/forget.md"));
@@ -266,6 +270,8 @@ const SCALE: &str = "-scale";
 const ROTATE: &str = "-rotate";
 const SKEW_X: &str = "-skewX";
 const SKEW_Y: &str = "-skewY";
+const INSERT: &str = "-insert";
+const CREATE_ELEMENT: &str = "-create-element";
 const FORGET: &str = "-forget";
 const SELECT: &str = "-select";
 const SELECT_MORE: &str = "-select-more";
@@ -346,6 +352,7 @@ fn parse(command_list: Vec<String>) -> anyhow::Result<Vec<oxvg_actions::Action<'
             SKEW_X => oxvg_actions::Action::SkewX(get_part_f32(&mut parts)?),
             SKEW_Y => oxvg_actions::Action::SkewY(get_part_f32(&mut parts)?),
             FORGET => oxvg_actions::Action::Forget,
+            INSERT | CREATE_ELEMENT => oxvg_actions::Action::Insert(get_part(&mut parts)?),
             SELECT => oxvg_actions::Action::Select(get_part(&mut parts)?),
             SELECT_MORE => oxvg_actions::Action::SelectMore(get_part(&mut parts)?),
             DESELECT => oxvg_actions::Action::Deselect,

--- a/crates/oxvg_actions/src/actions.rs
+++ b/crates/oxvg_actions/src/actions.rs
@@ -1,16 +1,26 @@
 use oxvg_ast::{arena::Allocator, node::Ref, serialize::Node};
-use oxvg_collections::{atom::Atom, attribute::core_attrs::Number};
+use oxvg_collections::{
+    atom::Atom,
+    attribute::{
+        core_attrs::{Integer, Number},
+        list_of::{ListOf, SpaceOrComma},
+    },
+};
 
+use oxvg_parse::Parse as _;
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
 mod manipulate;
 mod state;
+mod structure;
 mod transform;
 
 use crate::{
+    effects::StateEffect,
     error::Error,
-    state::{DerivedState, State},
+    state::{DerivedState, State, StateElement},
+    utils::get_oxvg_attr,
 };
 
 /// An actor holds a reference to a document to act upon.
@@ -21,7 +31,7 @@ pub struct Actor<'input, 'arena> {
     pub root: Ref<'input, 'arena>,
     /// The allocator associated with the given document
     pub allocator: Allocator<'input, 'arena>,
-    state: State<'input, 'arena>,
+    pub(crate) state: State<'input, 'arena>,
 }
 
 #[cfg_attr(feature = "wasm", derive(Tsify))]
@@ -66,6 +76,8 @@ pub enum Action<'input> {
     SkewX(Number),
     /// See [`Actor::skew_y`]
     SkewY(Number),
+    /// See [`Actor::insert`]
+    Insert(Atom<'input>),
     /// See [`Actor::forget`]
     Forget,
     /// See [`Actor::select`]
@@ -116,6 +128,8 @@ pub enum ActionNapi {
     SkewX(f64),
     /// See [`Actor::skew_y`]
     SkewY(f64),
+    /// See [`Actor::insert`]
+    Insert(String),
     /// See [`Actor::forget`]
     Forget,
     /// See [`Actor::select`]
@@ -150,7 +164,7 @@ impl<'input, 'arena> Actor<'input, 'arena> {
     ///
     /// If serialization fails, or if the document is missing a root element.
     pub fn snapshot(&mut self) -> Result<String, Error<'input>> {
-        self.state.embed(self.root)?;
+        self.effect_state(StateEffect::Embed)?;
         self.root
             .serialize()
             .map_err(|err| Error::SerializeError(err.to_string()))
@@ -173,24 +187,41 @@ impl<'input, 'arena> Actor<'input, 'arena> {
     /// When the associated action fails
     pub fn dispatch(&mut self, action: Action<'input>) -> Result<(), Error<'input>> {
         match action {
-            Action::Attr { name, value } => return self.attr(&name, &value),
-            Action::Class(name) => return self.class(&name),
-            Action::Style { property, value } => return self.style(&property, &value),
-            Action::PathIntersect => return self.path_intersect(),
-            Action::PathUnion => return self.path_union(),
-            Action::PathSubtract => return self.path_subtract(),
-            Action::PathXor => return self.path_xor(),
-            Action::Matrix(a, b, c, d, e, f) => return self.matrix(a, b, c, d, e, f),
-            Action::Translate(x, y) => return self.translate(x, y),
-            Action::Scale(x, y) => return self.scale(x, y),
-            Action::Rotate(angle, origin) => return self.rotate(angle, origin),
-            Action::SkewX(angle) => return self.skew_x(angle),
-            Action::SkewY(angle) => return self.skew_y(angle),
+            Action::Attr { name, value } => self.attr(&name, &value),
+            Action::Class(name) => self.class(&name),
+            Action::Style { property, value } => self.style(&property, &value),
+            Action::PathIntersect => self.path_intersect(),
+            Action::PathUnion => self.path_union(),
+            Action::PathSubtract => self.path_subtract(),
+            Action::PathXor => self.path_xor(),
+            Action::Matrix(a, b, c, d, e, f) => self.matrix(a, b, c, d, e, f),
+            Action::Translate(x, y) => self.translate(x, y),
+            Action::Scale(x, y) => self.scale(x, y),
+            Action::Rotate(angle, origin) => self.rotate(angle, origin),
+            Action::SkewX(angle) => self.skew_x(angle),
+            Action::SkewY(angle) => self.skew_y(angle),
+            Action::Insert(name) => self.insert(&name),
             Action::Forget => self.forget(),
-            Action::Select(query) => return self.select(&query),
-            Action::SelectMore(query) => return self.select_more(&query),
+            Action::Select(query) => self.select(&query),
+            Action::SelectMore(query) => self.select_more(&query),
             Action::Deselect => self.deselect(),
         }
-        Ok(())
+    }
+
+    pub(crate) fn get_selections_list(
+        &mut self,
+    ) -> Result<Option<ListOf<Integer, SpaceOrComma>>, Error<'input>> {
+        let selections_element = self.state.get_selections(&self.allocator);
+        let Some(selections) = get_oxvg_attr(&selections_element, StateElement::SELECTION_IDS)?
+        else {
+            return Ok(None);
+        };
+        ListOf::<Integer, SpaceOrComma>::parse_string(&selections)
+            .map_err(|err| Error::ParseError(err.to_string()))
+            .map(Some)
+    }
+
+    pub(crate) fn get_selections(&mut self) -> Result<Option<Vec<Integer>>, Error<'input>> {
+        Ok(self.get_selections_list()?.map(|s| s.list))
     }
 }

--- a/crates/oxvg_actions/src/actions/manipulate.rs
+++ b/crates/oxvg_actions/src/actions/manipulate.rs
@@ -4,15 +4,10 @@ use lightningcss::{declaration::DeclarationBlock, traits::Parse};
 use oxvg_ast::{get_attribute_mut, set_attribute};
 use oxvg_collections::{
     atom::Atom,
-    attribute::{
-        Attr, AttrId,
-        core_attrs::{Integer, Style},
-        list_of::{ListOf, SpaceOrComma},
-    },
+    attribute::{Attr, AttrId, core_attrs::Style},
 };
-use oxvg_parse::Parse as _;
 
-use crate::{Action, Actor, Error, state::StateElement, utils::get_oxvg_attr};
+use crate::{Action, Actor, Error};
 
 impl<'input> Actor<'input, '_> {
     /// Sets the attribute to selected elements.
@@ -25,13 +20,11 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../spec/manipulate/attr.md")]
     pub fn attr(&mut self, name: &str, value: &str) -> Result<(), Error<'input>> {
-        self.state.record(
-            &Action::Attr {
-                name: name.to_string().into(),
-                value: value.to_string().into(),
-            },
-            &self.allocator,
-        );
+        self.effect_history(&Action::Attr {
+            name: name.to_string().into(),
+            value: value.to_string().into(),
+        });
+
         let Some(selections) = self.get_selections()? else {
             return Ok(());
         };
@@ -52,7 +45,8 @@ impl<'input> Actor<'input, '_> {
             let attr = Attr::new(attr, value);
             element.set_attribute(attr);
         }
-        Ok(())
+
+        self.effect_document()
     }
 
     /// Toggles the class-name on selected elements.
@@ -66,8 +60,8 @@ impl<'input> Actor<'input, '_> {
     #[doc = include_str!("../spec/manipulate/class.md")]
     pub fn class(&mut self, name: &str) -> Result<(), Error<'input>> {
         let name: Atom<'static> = name.to_string().into();
-        self.state
-            .record(&Action::Class(name.clone()), &self.allocator);
+        self.effect_history(&Action::Class(name.clone()));
+
         let Some(selections) = self.get_selections()? else {
             return Ok(());
         };
@@ -82,7 +76,8 @@ impl<'input> Actor<'input, '_> {
             let mut class_list = element.class_list();
             class_list.toggle(name.clone());
         }
-        Ok(())
+
+        self.effect_document()
     }
 
     /// Appends the style to the selected elements style list.
@@ -96,13 +91,11 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../spec/manipulate/style.md")]
     pub fn style(&mut self, property: &str, value: &str) -> Result<(), Error<'input>> {
-        self.state.record(
-            &Action::Style {
-                property: property.to_string().into(),
-                value: value.to_string().into(),
-            },
-            &self.allocator,
-        );
+        self.effect_history(&Action::Style {
+            property: property.to_string().into(),
+            value: value.to_string().into(),
+        });
+
         let Some(selections) = self.get_selections()? else {
             return Ok(());
         };
@@ -152,25 +145,63 @@ impl<'input> Actor<'input, '_> {
                 set_attribute!(element, Style(style));
             }
         }
-        Ok(())
+
+        self.effect_document()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxvg_ast::serialize::Node as _;
+
+    use crate::Actor;
+
+    #[test]
+    fn attr() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("svg").unwrap();
+                actor.attr("width", "10").unwrap();
+                actor.attr("unknown", "foo").unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
     }
 
-    pub(crate) fn get_selections(&mut self) -> Result<Option<Vec<Integer>>, Error<'input>> {
-        Ok(self.get_selections_list()?.map(|s| s.list))
+    #[test]
+    fn class() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("svg").unwrap();
+                actor.class("my-class").unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
     }
 
-    pub(crate) fn get_selections_list(
-        &mut self,
-    ) -> Result<Option<ListOf<Integer, SpaceOrComma>>, Error<'input>> {
-        let selections_element = self.state.get_selections(&self.allocator);
-        if let Some(selections) =
-            get_oxvg_attr(&selections_element.clone(), StateElement::SELECTION_IDS)?
-        {
-            let selections = ListOf::<Integer, SpaceOrComma>::parse_string(&selections)
-                .map_err(|err| Error::ParseError(err.to_string()))?;
-            Ok(Some(selections))
-        } else {
-            Ok(None)
-        }
+    #[test]
+    fn style() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("svg").unwrap();
+                actor.style("opacity", "0.5").unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
     }
 }

--- a/crates/oxvg_actions/src/actions/manipulate/path.rs
+++ b/crates/oxvg_actions/src/actions/manipulate/path.rs
@@ -4,10 +4,10 @@ use oxvg_ast::{
     get_attribute, get_computed_style, has_attribute, is_element, set_attribute,
     style::{self, ComputedStyles},
 };
-use oxvg_collections::attribute::inheritable::Inheritable;
+use oxvg_collections::attribute::{core_attrs::Integer, inheritable::Inheritable};
 use oxvg_path::{algorithm::bool_ops::OverlayRule, geometry::Tolerance, paths::segment};
 
-use crate::{Action, Actor, Error, state::StateElement, utils::create_oxvg_attr};
+use crate::{Action, Actor, Error};
 
 impl<'input> Actor<'input, '_> {
     /// Intersects selected path definitions.
@@ -20,7 +20,12 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../../spec/manipulate/path_intersect.md")]
     pub fn path_intersect(&mut self) -> Result<(), Error<'input>> {
-        self.boolean_op(&Action::PathIntersect, OverlayRule::Intersect)
+        self.effect_history(&Action::PathIntersect);
+        if let Some(selection) = self.boolean_op(OverlayRule::Intersect)? {
+            self.effect_selection(&selection.into())?;
+        }
+        self.effect_tree()?;
+        self.effect_document()
     }
 
     /// Unites selected path definitions.
@@ -33,7 +38,12 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../../spec/manipulate/path_union.md")]
     pub fn path_union(&mut self) -> Result<(), Error<'input>> {
-        self.boolean_op(&Action::PathUnion, OverlayRule::Union)
+        self.effect_history(&Action::PathUnion);
+        if let Some(selection) = self.boolean_op(OverlayRule::Union)? {
+            self.effect_selection(&selection.into())?;
+        }
+        self.effect_tree()?;
+        self.effect_document()
     }
 
     /// Subtracts selected path definitions.
@@ -46,7 +56,12 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../../spec/manipulate/path_subtract.md")]
     pub fn path_subtract(&mut self) -> Result<(), Error<'input>> {
-        self.boolean_op(&Action::PathSubtract, OverlayRule::Difference)
+        self.effect_history(&Action::PathSubtract);
+        if let Some(selection) = self.boolean_op(OverlayRule::Difference)? {
+            self.effect_selection(&selection.into())?;
+        }
+        self.effect_tree()?;
+        self.effect_document()
     }
 
     /// XORs selected path definitions.
@@ -59,24 +74,24 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../../spec/manipulate/path_xor.md")]
     pub fn path_xor(&mut self) -> Result<(), Error<'input>> {
-        self.boolean_op(&Action::PathXor, OverlayRule::Xor)
+        self.effect_history(&Action::PathXor);
+        if let Some(selection) = self.boolean_op(OverlayRule::Xor)? {
+            self.effect_selection(&selection.into())?;
+        }
+        self.effect_tree()?;
+        self.effect_document()
     }
 
-    fn boolean_op(
-        &mut self,
-        action: &Action<'input>,
-        overlay_rule: OverlayRule,
-    ) -> Result<(), Error<'input>> {
-        self.state.record(action, &self.allocator);
+    fn boolean_op(&mut self, overlay_rule: OverlayRule) -> Result<Option<Integer>, Error<'input>> {
         let Some(selections) = self.get_selections()? else {
-            return Ok(());
+            return Ok(None);
         };
         let Some(root) = Element::from_parent(self.root) else {
-            return Ok(());
+            return Ok(None);
         };
         let mut cumulative_path: Option<oxvg_path::paths::bool::Path> = None;
         let mut previous_element: Option<Element> = None;
-        let styles: Vec<_> = style::root(&root).collect();
+        let styles: Vec<_> = style::root(root).collect();
         #[allow(clippy::cast_sign_loss)]
         let paths: Vec<_> = selections
             .iter()
@@ -89,7 +104,7 @@ impl<'input> Actor<'input, '_> {
             let segment_path = segment::Path::from_svg(&d, &Tolerance::default());
             drop(d);
             let computed_styles = ComputedStyles::default()
-                .with_all(&path, &styles)
+                .with_all(path, &styles)
                 .map_err(|err| Error::ComputedStylesError(err.to_string()))?;
             let evenodd = get_computed_style!(computed_styles, FillRule)
                 .option()
@@ -129,19 +144,90 @@ impl<'input> Actor<'input, '_> {
                 FillRule(Inheritable::Defined(FillRule::Evenodd))
             );
         }
+        #[allow(clippy::cast_possible_wrap)]
+        Ok(previous_element.map(|e| e.id() as Integer))
+    }
+}
 
-        if let Some(selection) = selections.last() {
-            self.state
-                .get_selections(&self.allocator)
-                .set_attribute(create_oxvg_attr(
-                    StateElement::SELECTION_IDS,
-                    #[allow(clippy::cast_sign_loss)]
-                    ((*selection as usize) - selections.len())
-                        .to_string()
-                        .into(),
-                ));
-        }
-        self.state.embed(self.root)?;
-        Ok(())
+#[cfg(test)]
+mod test {
+    use oxvg_ast::serialize::Node as _;
+
+    use crate::Actor;
+
+    #[test]
+    fn intersect() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 2 2h8v8H2z" />
+    <path d="M7 7a4 4 0 1 0 0.001 -0.001zM7.35 7.35 a3.5 3.5 0 1 0 0.001 -0.001z" fill-rule="evenodd" />
+</svg>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("path").unwrap();
+                actor.path_intersect().unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn union() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 2 2h8v8H2z" />
+    <path d="M7 7a4 4 0 1 0 0.001 -0.001zM7.35 7.35 a3.5 3.5 0 1 0 0.001 -0.001z" fill-rule="evenodd" />
+</svg>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("path").unwrap();
+                actor.path_union().unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn subtract() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 2 2h8v8H2z" />
+    <path d="M7 7a4 4 0 1 0 0.001 -0.001zM7.35 7.35 a3.5 3.5 0 1 0 0.001 -0.001z" fill-rule="evenodd" />
+</svg>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("path").unwrap();
+                actor.path_subtract().unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn xor() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 2 2h8v8H2z" />
+    <path d="M7 7a4 4 0 1 0 0.001 -0.001zM7.35 7.35 a3.5 3.5 0 1 0 0.001 -0.001z" fill-rule="evenodd" />
+</svg>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("path").unwrap();
+                actor.path_xor().unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
     }
 }

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__intersect-2.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__intersect-2.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "path",
+            ),
+        ),
+        PathIntersect,
+    ],
+    selection: [
+        4,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Path,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    ClipPath,
+                    Marker,
+                    Mask,
+                    Script,
+                    Style,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    D,
+                    ExternalResourcesRequired,
+                    PathLength,
+                },
+                values: {
+                    D: Cow(
+                        "M5.833 10a4 4 0 0 1 4.165-4.168l.001.497a3.5 3.5 0 0 0-3.67 3.67Z",
+                    ),
+                    FillRule: Cow(
+                        "evenodd",
+                    ),
+                },
+            },
+            text: Some(
+                Static(
+                    "",
+                ),
+            ),
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__intersect.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__intersect.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me"><path d="M5.833 10a4 4 0 0 1 4.165-4.168l.001.497a3.5 3.5 0 0 0-3.67 3.67Z" fill-rule="evenodd"/><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>path</oxvg:arg></oxvg:action><oxvg:action oxvg:id="PathIntersect"/></oxvg:history><oxvg:selection oxvg:ids="4"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__subtract-2.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__subtract-2.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "path",
+            ),
+        ),
+        PathSubtract,
+    ],
+    selection: [
+        4,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Path,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    ClipPath,
+                    Marker,
+                    Mask,
+                    Script,
+                    Style,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    D,
+                    ExternalResourcesRequired,
+                    PathLength,
+                },
+                values: {
+                    D: Cow(
+                        "M2 10V2h8v3.832a4 4 0 0 0-4.167 4.166ZM6.33 9.997a3.5 3.5 0 0 1 3.669-3.668L10 10H6.33Z",
+                    ),
+                    FillRule: Cow(
+                        "evenodd",
+                    ),
+                },
+            },
+            text: Some(
+                Static(
+                    "",
+                ),
+            ),
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__subtract.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__subtract.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me"><path d="M2 10V2h8v3.832a4 4 0 0 0-4.167 4.166ZM6.33 9.997a3.5 3.5 0 0 1 3.669-3.668L10 10H6.33Z" fill-rule="evenodd"/><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>path</oxvg:arg></oxvg:action><oxvg:action oxvg:id="PathSubtract"/></oxvg:history><oxvg:selection oxvg:ids="4"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__union-2.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__union-2.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "path",
+            ),
+        ),
+        PathUnion,
+    ],
+    selection: [
+        4,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Path,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    ClipPath,
+                    Marker,
+                    Mask,
+                    Script,
+                    Style,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    D,
+                    ExternalResourcesRequired,
+                    PathLength,
+                },
+                values: {
+                    D: Cow(
+                        "M2 10V2h8v3.832A4 4 0 1 1 5.833 10ZM6.33 10A3.5 3.5 0 1 0 10 6.329V10Z",
+                    ),
+                    FillRule: Cow(
+                        "evenodd",
+                    ),
+                },
+            },
+            text: Some(
+                Static(
+                    "",
+                ),
+            ),
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__union.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__union.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me"><path d="M2 10V2h8v3.832A4 4 0 1 1 5.833 10ZM6.33 10A3.5 3.5 0 1 0 10 6.329V10Z" fill-rule="evenodd"/><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>path</oxvg:arg></oxvg:action><oxvg:action oxvg:id="PathUnion"/></oxvg:history><oxvg:selection oxvg:ids="4"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__xor-2.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__xor-2.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "path",
+            ),
+        ),
+        PathXor,
+    ],
+    selection: [
+        4,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Path,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    ClipPath,
+                    Marker,
+                    Mask,
+                    Script,
+                    Style,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    D,
+                    ExternalResourcesRequired,
+                    PathLength,
+                },
+                values: {
+                    D: Cow(
+                        "M2 10V2h8v3.832a4 4 0 0 0-4.167 4.166ZM5.834 10.025A4 4 0 0 1 5.833 10h.497A3.5 3.5 0 1 0 10 6.329v-.497a4 4 0 1 1-4.152 4.388ZM6.33 9.997a3.5 3.5 0 0 1 3.669-3.668L10 10H6.33Z",
+                    ),
+                    FillRule: Cow(
+                        "evenodd",
+                    ),
+                },
+            },
+            text: Some(
+                Static(
+                    "",
+                ),
+            ),
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__xor.snap
+++ b/crates/oxvg_actions/src/actions/manipulate/snapshots/oxvg_actions__actions__manipulate__path__test__xor.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate/path.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me"><path d="M2 10V2h8v3.832a4 4 0 0 0-4.167 4.166ZM5.834 10.025A4 4 0 0 1 5.833 10h.497A3.5 3.5 0 1 0 10 6.329v-.497a4 4 0 1 1-4.152 4.388ZM6.33 9.997a3.5 3.5 0 0 1 3.669-3.668L10 10H6.33Z" fill-rule="evenodd"/><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>path</oxvg:arg></oxvg:action><oxvg:action oxvg:id="PathXor"/></oxvg:history><oxvg:selection oxvg:ids="4"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__attr-2.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__attr-2.snap
@@ -1,0 +1,104 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "svg",
+            ),
+        ),
+        Attr {
+            name: Cow(
+                "width",
+            ),
+            value: Cow(
+                "10",
+            ),
+        },
+        Attr {
+            name: Cow(
+                "unknown",
+            ),
+            value: Cow(
+                "foo",
+            ),
+        },
+    ],
+    selection: [
+        1,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Svg,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    A,
+                    AltGlyphDef,
+                    ClipPath,
+                    ColorProfile,
+                    Cursor,
+                    Filter,
+                    Font,
+                    FontFace,
+                    ForeignObject,
+                    Image,
+                    Marker,
+                    Mask,
+                    Pattern,
+                    Script,
+                    Style,
+                    Switch,
+                    Text,
+                    View,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    BaseProfile,
+                    ContentScriptType,
+                    ContentStyleType,
+                    ExternalResourcesRequired,
+                    HeightSvg,
+                    Playbackorder,
+                    PreserveAspectRatio,
+                    Timelinebegin,
+                    Version,
+                    ViewBox,
+                    WidthSvg,
+                    XGeometry,
+                    YGeometry,
+                    ZoomAndPan,
+                },
+                values: {
+                    WidthSvg: Cow(
+                        "10",
+                    ),
+                    XMLNS: Cow(
+                        "http://www.w3.org/2000/svg",
+                    ),
+                    Unknown(
+                        QualName {
+                            prefix: XMLNS,
+                            local: Cow(
+                                "oxvg",
+                            ),
+                        },
+                    ): Cow(
+                        "https://oxvg.noahwbaldwin.me",
+                    ),
+                },
+            },
+            text: None,
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__attr.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__attr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me" width="10"><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>svg</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Attr"><oxvg:arg>width</oxvg:arg><oxvg:arg>10</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Attr"><oxvg:arg>unknown</oxvg:arg><oxvg:arg>foo</oxvg:arg></oxvg:action></oxvg:history><oxvg:selection oxvg:ids="1"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__class-2.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__class-2.snap
@@ -1,0 +1,93 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "svg",
+            ),
+        ),
+        Class(
+            Cow(
+                "my-class",
+            ),
+        ),
+    ],
+    selection: [
+        1,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Svg,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    A,
+                    AltGlyphDef,
+                    ClipPath,
+                    ColorProfile,
+                    Cursor,
+                    Filter,
+                    Font,
+                    FontFace,
+                    ForeignObject,
+                    Image,
+                    Marker,
+                    Mask,
+                    Pattern,
+                    Script,
+                    Style,
+                    Switch,
+                    Text,
+                    View,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    BaseProfile,
+                    ContentScriptType,
+                    ContentStyleType,
+                    ExternalResourcesRequired,
+                    HeightSvg,
+                    Playbackorder,
+                    PreserveAspectRatio,
+                    Timelinebegin,
+                    Version,
+                    ViewBox,
+                    WidthSvg,
+                    XGeometry,
+                    YGeometry,
+                    ZoomAndPan,
+                },
+                values: {
+                    Class: Cow(
+                        "my-class",
+                    ),
+                    XMLNS: Cow(
+                        "http://www.w3.org/2000/svg",
+                    ),
+                    Unknown(
+                        QualName {
+                            prefix: XMLNS,
+                            local: Cow(
+                                "oxvg",
+                            ),
+                        },
+                    ): Cow(
+                        "https://oxvg.noahwbaldwin.me",
+                    ),
+                },
+            },
+            text: None,
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__class.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__class.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me" class="my-class"><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>svg</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Class"><oxvg:arg>my-class</oxvg:arg></oxvg:action></oxvg:history><oxvg:selection oxvg:ids="1"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__style-2.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__style-2.snap
@@ -1,0 +1,96 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "svg",
+            ),
+        ),
+        Style {
+            property: Cow(
+                "opacity",
+            ),
+            value: Cow(
+                "0.5",
+            ),
+        },
+    ],
+    selection: [
+        1,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Svg,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    A,
+                    AltGlyphDef,
+                    ClipPath,
+                    ColorProfile,
+                    Cursor,
+                    Filter,
+                    Font,
+                    FontFace,
+                    ForeignObject,
+                    Image,
+                    Marker,
+                    Mask,
+                    Pattern,
+                    Script,
+                    Style,
+                    Switch,
+                    Text,
+                    View,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    BaseProfile,
+                    ContentScriptType,
+                    ContentStyleType,
+                    ExternalResourcesRequired,
+                    HeightSvg,
+                    Playbackorder,
+                    PreserveAspectRatio,
+                    Timelinebegin,
+                    Version,
+                    ViewBox,
+                    WidthSvg,
+                    XGeometry,
+                    YGeometry,
+                    ZoomAndPan,
+                },
+                values: {
+                    Style: Cow(
+                        "opacity: .5",
+                    ),
+                    XMLNS: Cow(
+                        "http://www.w3.org/2000/svg",
+                    ),
+                    Unknown(
+                        QualName {
+                            prefix: XMLNS,
+                            local: Cow(
+                                "oxvg",
+                            ),
+                        },
+                    ): Cow(
+                        "https://oxvg.noahwbaldwin.me",
+                    ),
+                },
+            },
+            text: None,
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__style.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__manipulate__test__style.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/manipulate.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me" style="opacity:.5"><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>svg</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Style"><oxvg:arg>opacity</oxvg:arg><oxvg:arg>0.5</oxvg:arg></oxvg:action></oxvg:history><oxvg:selection oxvg:ids="1"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__deselect-2.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__deselect-2.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxvg_actions/src/actions/state.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "path",
+            ),
+        ),
+        Deselect,
+    ],
+    selection: [],
+    info: Some(
+        Info {
+            element_id: None,
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    0x0,
+                ),
+                permitted_elements: {},
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    0x0,
+                ),
+                expected_attributes: {},
+                values: {},
+            },
+            text: Some(
+                Static(
+                    "",
+                ),
+            ),
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__deselect.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__deselect.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/state.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me"><g color="#000"/><g color="#000"/><path fill="#404040"/><path fill="#404040"/><path fill="#dcddde"/><path fill="#0064ff"/><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>path</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Deselect"/></oxvg:history></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__forget-2.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__forget-2.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxvg_actions/src/actions/state.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "path",
+            ),
+        ),
+        Forget,
+    ],
+    selection: [],
+    info: Some(
+        Info {
+            element_id: None,
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    0x0,
+                ),
+                permitted_elements: {},
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    0x0,
+                ),
+                expected_attributes: {},
+                values: {},
+            },
+            text: Some(
+                Static(
+                    "",
+                ),
+            ),
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__forget.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__state__test__forget.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/state.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"/>

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__transform__test__transforms-2.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__transform__test__transforms-2.snap
@@ -1,0 +1,123 @@
+---
+source: crates/oxvg_actions/src/actions/transform.rs
+expression: actor.derive_state().unwrap()
+---
+DerivedState {
+    history: [
+        Select(
+            Cow(
+                "svg",
+            ),
+        ),
+        Matrix(
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+        ),
+        Translate(
+            1.0,
+            Some(
+                1.0,
+            ),
+        ),
+        Scale(
+            1.0,
+            Some(
+                1.0,
+            ),
+        ),
+        Rotate(
+            90.0,
+            Some(
+                (
+                    1.0,
+                    1.0,
+                ),
+            ),
+        ),
+        SkewX(
+            1.0,
+        ),
+        SkewY(
+            1.0,
+        ),
+    ],
+    selection: [
+        1,
+    ],
+    info: Some(
+        Info {
+            element_id: Some(
+                Svg,
+            ),
+            content_model: ContentModel {
+                permitted_categories: ElementCategory(
+                    Animation | BasicShape | Container | Descriptive | FilterPrimitive | Gradient | Graphics | GraphicsReferencing | LightSource | NeverRendered | PaintServer | Renderable | Shape | Structural | StructurallyExternal | TextContent | TextContentChild | TransferFunction | Uncategorised,
+                ),
+                permitted_elements: {
+                    A,
+                    AltGlyphDef,
+                    ClipPath,
+                    ColorProfile,
+                    Cursor,
+                    Filter,
+                    Font,
+                    FontFace,
+                    ForeignObject,
+                    Image,
+                    Marker,
+                    Mask,
+                    Pattern,
+                    Script,
+                    Style,
+                    Switch,
+                    Text,
+                    View,
+                },
+            },
+            attributes: AttrModel {
+                expected_attribute_groups: AttributeGroup(
+                    AnimationAddition | AnimationAttributeTarget | AnimationEvent | AnimationTargetElement | AnimationTiming | AnimationValue | Aria | ConditionalProcessing | Core | DocumentEvent | DocumentElementEvent | FilterPrimitive | GraphicalEvent | GlobalEvent | Presentation | TransferFunction | XLink,
+                ),
+                expected_attributes: {
+                    BaseProfile,
+                    ContentScriptType,
+                    ContentStyleType,
+                    ExternalResourcesRequired,
+                    HeightSvg,
+                    Playbackorder,
+                    PreserveAspectRatio,
+                    Timelinebegin,
+                    Version,
+                    ViewBox,
+                    WidthSvg,
+                    XGeometry,
+                    YGeometry,
+                    ZoomAndPan,
+                },
+                values: {
+                    Transform: Cow(
+                        "matrix(1 2 3 4 5 6)translate(1 1)scale(1)rotate(90 1 1)skewX(1)skewY(1)",
+                    ),
+                    XMLNS: Cow(
+                        "http://www.w3.org/2000/svg",
+                    ),
+                    Unknown(
+                        QualName {
+                            prefix: XMLNS,
+                            local: Cow(
+                                "oxvg",
+                            ),
+                        },
+                    ): Cow(
+                        "https://oxvg.noahwbaldwin.me",
+                    ),
+                },
+            },
+            text: None,
+        },
+    ),
+}

--- a/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__transform__test__transforms.snap
+++ b/crates/oxvg_actions/src/actions/snapshots/oxvg_actions__actions__transform__test__transforms.snap
@@ -1,0 +1,5 @@
+---
+source: crates/oxvg_actions/src/actions/transform.rs
+expression: actor.root.serialize().unwrap()
+---
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:oxvg="https://oxvg.noahwbaldwin.me" transform="matrix(1 2 3 4 5 6)translate(1 1)scale(1)rotate(90 1 1)skewX(1)skewY(1)"><oxvg:state><oxvg:history><oxvg:action oxvg:id="Select"><oxvg:arg>svg</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Matrix"><oxvg:arg>1</oxvg:arg><oxvg:arg>2</oxvg:arg><oxvg:arg>3</oxvg:arg><oxvg:arg>4</oxvg:arg><oxvg:arg>5</oxvg:arg><oxvg:arg>6</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Translate"><oxvg:arg>1</oxvg:arg><oxvg:arg>1</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Scale"><oxvg:arg>1</oxvg:arg><oxvg:arg>1</oxvg:arg></oxvg:action><oxvg:action oxvg:id="Rotate"><oxvg:arg>90</oxvg:arg><oxvg:arg>1</oxvg:arg><oxvg:arg>1</oxvg:arg></oxvg:action><oxvg:action oxvg:id="SkewX"><oxvg:arg>1</oxvg:arg></oxvg:action><oxvg:action oxvg:id="SkewY"><oxvg:arg>1</oxvg:arg></oxvg:action></oxvg:history><oxvg:selection oxvg:ids="1"/></oxvg:state></svg>

--- a/crates/oxvg_actions/src/actions/state.rs
+++ b/crates/oxvg_actions/src/actions/state.rs
@@ -1,30 +1,37 @@
 use oxvg_collections::{
-    atom::Atom,
     attribute::{
+        AttrId,
         core_attrs::Integer,
         list_of::{ListOf, SpaceOrComma},
     },
+    name::{Prefix, QualName},
 };
 use oxvg_parse::Parse as _;
-use oxvg_serialize::{PrinterOptions, ToValue as _};
 
-use crate::{
-    state::StateElement,
-    utils::{create_oxvg_attr, create_oxvg_attr_id, get_oxvg_attr},
-    Action, Actor, Error,
-};
+use crate::{Action, Actor, Error, OXVG_PREFIX, effects::StateEffect};
 
 impl<'input> Actor<'input, '_> {
     /// Removes OXVG state from the document
     ///
+    /// # Errors
+    ///
+    /// When root element is missing.
+    ///
     /// # Spec
     ///
     #[doc = include_str!("../spec/state/forget.md")]
-    pub fn forget(&mut self) {
-        self.state.record(&Action::Forget, &self.allocator);
+    pub fn forget(&mut self) -> Result<(), Error<'input>> {
+        self.effect_history(&Action::Forget);
 
-        self.deselect_internal();
-        self.state.state.remove();
+        self.effect_selection(&vec![].into())?;
+        self.effect_state(StateEffect::Remove)?;
+        if let Some(root) = self.root.find_element() {
+            root.remove_attribute(&AttrId::Unknown(QualName {
+                prefix: Prefix::XMLNS,
+                local: OXVG_PREFIX.into(),
+            }));
+        }
+        Ok(())
     }
 
     /// Updates the state of the actor to point to the elements matching the given selector.
@@ -39,19 +46,10 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../spec/state/select.md")]
     pub fn select(&mut self, query: &str) -> Result<(), Error<'input>> {
-        self.state
-            .record(&Action::Select(query.to_string().into()), &self.allocator);
+        self.effect_history(&Action::Select(query.to_string().into()));
 
         let selections = self.select_internal(query)?;
-        let selections = selections
-            .to_value_string(PrinterOptions::default())
-            .map_err(|err| Error::SerializeError(err.to_string()))?
-            .into();
-
-        self.state
-            .get_selections(&self.allocator)
-            .set_attribute(create_oxvg_attr(StateElement::SELECTION_IDS, selections));
-        self.state.embed(self.root)
+        self.effect_selection(&selections)
     }
 
     /// Updates the state of the actor to point to the elements matching the given selector,
@@ -67,39 +65,27 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../spec/state/select-more.md")]
     pub fn select_more(&mut self, query: &str) -> Result<(), Error<'input>> {
-        self.state.record(
-            &Action::SelectMore(query.to_string().into()),
-            &self.allocator,
-        );
+        self.effect_history(&Action::SelectMore(query.to_string().into()));
 
-        let selections = self.select_internal(query)?;
-        let selections: Atom = selections
-            .to_value_string(PrinterOptions::default())
-            .map_err(|err| Error::SerializeError(err.to_string()))?
-            .into();
-        let state_selections = self.state.get_selections(&self.allocator);
-        let new_selections =
-            match get_oxvg_attr(&state_selections, StateElement::SELECTION_IDS)?.as_deref() {
-                Some(value) => format!("{value},{selections}").into(),
-                None => selections,
-            };
+        let mut selections = self.get_selections_list()?.unwrap_or_default();
+        let new_selections = self.select_internal(query)?;
+        selections.list.extend(new_selections.list);
 
-        state_selections.set_attribute(create_oxvg_attr(
-            StateElement::SELECTION_IDS,
-            new_selections,
-        ));
-        self.state.embed(self.root)
+        self.effect_selection(&selections)
     }
 
     /// Updates the state of the actor to deselected any selected nodes.
     ///
+    /// # Errors
+    ///
+    /// When root element is missing.
+    ///
     /// # Spec
     ///
     #[doc = include_str!("../spec/state/deselect.md")]
-    pub fn deselect(&mut self) {
-        self.state.record(&Action::Deselect, &self.allocator);
-
-        self.deselect_internal();
+    pub fn deselect(&mut self) -> Result<(), Error<'input>> {
+        self.effect_history(&Action::Deselect);
+        self.effect_selection(&vec![].into())
     }
 
     fn select_internal(
@@ -117,19 +103,8 @@ impl<'input> Actor<'input, '_> {
                 .map_err(|_| Error::InvalidSelector(query.to_string()))?;
 
             #[allow(clippy::cast_possible_wrap)]
-            let selections: Vec<_> = elements.map(|e| e.id() as Integer).collect();
-
-            Ok(ListOf {
-                list: selections,
-                separator: SpaceOrComma,
-            })
+            Ok(elements.map(|e| e.id() as Integer).collect())
         }
-    }
-
-    fn deselect_internal(&mut self) {
-        self.state
-            .get_selections(&self.allocator)
-            .remove_attribute(&create_oxvg_attr_id(StateElement::SELECTION_IDS));
     }
 }
 
@@ -175,6 +150,45 @@ mod test {
                 insta::assert_debug_snapshot!(actor.derive_state().unwrap());
 
                 actor.select("7, 9").unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deselect() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg">
+    <g color="black"/>
+    <g color="BLACK"/>
+    <path fill="rgb(64 64 64)"/>
+    <path fill="rgb(64, 64, 64)"/>
+    <path fill="rgb(86.27451%,86.666667%,87.058824%)"/>
+    <path fill="rgb(-255,100,500)"/>
+</svg>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("path").unwrap();
+                actor.deselect().unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn forget() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"/>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("path").unwrap();
+                actor.forget().unwrap();
                 insta::assert_snapshot!(actor.root.serialize().unwrap());
                 insta::assert_debug_snapshot!(actor.derive_state().unwrap());
             },

--- a/crates/oxvg_actions/src/actions/structure.rs
+++ b/crates/oxvg_actions/src/actions/structure.rs
@@ -1,0 +1,1 @@
+mod creation;

--- a/crates/oxvg_actions/src/actions/structure/creation.rs
+++ b/crates/oxvg_actions/src/actions/structure/creation.rs
@@ -1,0 +1,64 @@
+use oxvg_ast::{element::Element, node::Node};
+use oxvg_collections::{
+    atom::Atom,
+    attribute::core_attrs::Integer,
+    element::ElementId,
+    name::{NS, Prefix},
+};
+
+use crate::{Action, Actor, Error};
+
+impl<'input> Actor<'input, '_> {
+    /// Creates a new SVG element and inserts it into the current selection.
+    ///
+    /// # Errors
+    ///
+    /// When root element is missing.
+    ///
+    /// # Spec
+    ///
+    #[doc = include_str!("../../spec/structure/insert.md")]
+    pub fn insert(&mut self, qual_name: &Atom<'input>) -> Result<(), Error<'input>> {
+        self.effect_history(&Action::Insert(qual_name.clone()));
+
+        let Some(selections) = self.get_selections()? else {
+            return Ok(());
+        };
+        let Some(root) = Element::from_parent(self.root) else {
+            return Ok(());
+        };
+        let document = root.as_document();
+        let (prefix, local_name) = match qual_name.split_once(':') {
+            Some((prefix, local_name)) => (
+                Some((*self.allocator.alloc_str(prefix)).into()),
+                (*self.allocator.alloc_str(local_name)).into(),
+            ),
+            None => (None, qual_name.clone()),
+        };
+        let prefix = Prefix::new(NS::SVG.uri().clone(), prefix);
+        let element = ElementId::new(prefix, local_name);
+
+        #[allow(clippy::cast_sign_loss)]
+        let selections = selections
+            .into_iter()
+            .filter_map(|s| self.allocator.get(s as usize))
+            .filter_map(Node::element)
+            .collect::<Vec<_>>();
+        let mut new_elements = Vec::with_capacity(selections.len());
+        for selected in selections {
+            let element = document.create_element(element.clone(), &self.allocator);
+            new_elements.push(element);
+            selected.append(*element);
+        }
+
+        self.effect_selection(
+            #[allow(clippy::cast_possible_wrap)]
+            &new_elements
+                .into_iter()
+                .map(|n| n.id() as Integer)
+                .collect(),
+        )?;
+        self.effect_tree()?;
+        self.effect_document()
+    }
+}

--- a/crates/oxvg_actions/src/actions/transform.rs
+++ b/crates/oxvg_actions/src/actions/transform.rs
@@ -1,10 +1,10 @@
 use lightningcss::properties::transform::Matrix;
 use oxvg_ast::{get_attribute_mut, set_attribute};
 use oxvg_collections::attribute::{
+    AttrId,
     core_attrs::Number,
     inheritable::Inheritable,
     transform::{SVGTransform, SVGTransformList},
-    AttrId,
 };
 
 use crate::{Action, Actor, Error};
@@ -29,9 +29,9 @@ impl<'input> Actor<'input, '_> {
         e: Number,
         f: Number,
     ) -> Result<(), Error<'input>> {
-        self.state
-            .record(&Action::Matrix(a, b, c, d, e, f), &self.allocator);
-        self.append_transform(&SVGTransform::Matrix(Matrix { a, b, c, d, e, f }))
+        self.effect_history(&Action::Matrix(a, b, c, d, e, f));
+        self.append_transform(&SVGTransform::Matrix(Matrix { a, b, c, d, e, f }))?;
+        self.effect_document()
     }
 
     /// Appends the `translate` function to the element's `transform` attribute.
@@ -44,8 +44,9 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../spec/manipulate/translate.md")]
     pub fn translate(&mut self, x: Number, y: Option<Number>) -> Result<(), Error<'input>> {
-        self.state.record(&Action::Translate(x, y), &self.allocator);
-        self.append_transform(&SVGTransform::Translate(x, y.unwrap_or_default()))
+        self.effect_history(&Action::Translate(x, y));
+        self.append_transform(&SVGTransform::Translate(x, y.unwrap_or_default()))?;
+        self.effect_document()
     }
 
     /// Appends the `scale` function to the element's `transform` attribute.
@@ -58,8 +59,9 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../spec/manipulate/scale.md")]
     pub fn scale(&mut self, x: Number, y: Option<Number>) -> Result<(), Error<'input>> {
-        self.state.record(&Action::Scale(x, y), &self.allocator);
-        self.append_transform(&SVGTransform::Scale(x, y.unwrap_or(x)))
+        self.effect_history(&Action::Scale(x, y));
+        self.append_transform(&SVGTransform::Scale(x, y.unwrap_or(x)))?;
+        self.effect_document()
     }
 
     /// Appends the `rotate` function to the element's `transform` attribute.
@@ -76,8 +78,7 @@ impl<'input> Actor<'input, '_> {
         angle: Number,
         origin: Option<(Number, Number)>,
     ) -> Result<(), Error<'input>> {
-        self.state
-            .record(&Action::Rotate(angle, origin), &self.allocator);
+        self.effect_history(&Action::Rotate(angle, origin));
         let (x, y) = origin.unwrap_or((0.0, 0.0));
         self.append_transform(&SVGTransform::Rotate(angle, x, y))
     }
@@ -106,8 +107,9 @@ impl<'input> Actor<'input, '_> {
     ///
     #[doc = include_str!("../spec/manipulate/skewY.md")]
     pub fn skew_y(&mut self, angle: Number) -> Result<(), Error<'input>> {
-        self.state.record(&Action::SkewY(angle), &self.allocator);
-        self.append_transform(&SVGTransform::SkewY(angle))
+        self.effect_history(&Action::SkewY(angle));
+        self.append_transform(&SVGTransform::SkewY(angle))?;
+        self.effect_document()
     }
 
     fn append_transform(&mut self, transform: &SVGTransform) -> Result<(), Error<'input>> {
@@ -140,5 +142,33 @@ impl<'input> Actor<'input, '_> {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxvg_ast::serialize::Node as _;
+
+    use crate::Actor;
+
+    #[test]
+    fn transforms() {
+        oxvg_ast::parse::roxmltree::parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#,
+            |root, allocator| {
+                let mut actor = Actor::new(root, allocator).unwrap();
+
+                actor.select("svg").unwrap();
+                actor.matrix(1.0, 2.0, 3.0, 4.0, 5.0, 6.0).unwrap();
+                actor.translate(1.0, Some(1.0)).unwrap();
+                actor.scale(1.0, Some(1.0)).unwrap();
+                actor.rotate(90.0, Some((1.0, 1.0))).unwrap();
+                actor.skew_x(1.0).unwrap();
+                actor.skew_y(1.0).unwrap();
+                insta::assert_snapshot!(actor.root.serialize().unwrap());
+                insta::assert_debug_snapshot!(actor.derive_state().unwrap());
+            },
+        )
+        .unwrap();
     }
 }

--- a/crates/oxvg_actions/src/effects.rs
+++ b/crates/oxvg_actions/src/effects.rs
@@ -1,0 +1,95 @@
+//! Effects are required to effectively commit action changes to the document.
+//!
+//! Some code style rules regarding effects:
+//! - Effect should be called only for action methods, not in utility functions used by actions.
+//! - Effects should called when all relevant actions make an effect, as specified in `./spec/`.
+use oxvg_collections::{
+    atom::Atom,
+    attribute::{
+        core_attrs::Integer,
+        list_of::{ListOf, SpaceOrComma},
+    },
+};
+use oxvg_serialize::{PrinterOptions, ToValue as _};
+
+use crate::{
+    Action, Actor, Error,
+    state::StateElement,
+    utils::{create_oxvg_attr, create_oxvg_attr_id},
+};
+
+#[derive(Clone, Copy)]
+pub(crate) enum StateEffect {
+    Remove,
+    Embed,
+}
+
+impl<'input> Actor<'input, '_> {
+    /// Should be called for direct state manipulation
+    pub(crate) fn effect_state(&mut self, effect: StateEffect) -> Result<(), Error<'input>> {
+        match effect {
+            StateEffect::Remove => {
+                self.state.state.remove();
+                Ok(())
+            }
+            StateEffect::Embed => self.state.embed(self.root),
+        }
+    }
+
+    /// Must be called at the start of an action that affects history.
+    pub(crate) fn effect_history(&mut self, action: &Action<'input>) {
+        self.state.record(action, &self.allocator);
+    }
+
+    // TODO: pub fn clipboard
+
+    /// Must be the last call of an action that affects the document. Doesn't
+    /// need to be called for early returns prior to affecting the document.
+    ///
+    /// This is a no-op, but may run assertions or other operations in future.
+    #[allow(clippy::unnecessary_wraps)]
+    #[allow(clippy::unused_self)]
+    #[inline]
+    pub(crate) fn effect_document(&self) -> Result<(), Error<'static>> {
+        Ok(())
+    }
+
+    /// Must be called at the end of an action that affects selection.
+    pub(crate) fn effect_selection(
+        &mut self,
+        selections: &ListOf<Integer, SpaceOrComma>,
+    ) -> Result<(), Error<'input>> {
+        let state_selections = self.state.get_selections(&self.allocator);
+        if selections.list.is_empty() {
+            state_selections.remove_attribute(&create_oxvg_attr_id(StateElement::SELECTION_IDS));
+            state_selections.remove();
+            return Ok(());
+        }
+
+        let selections: Atom = selections
+            .to_value_string(PrinterOptions::default())
+            .map_err(|err| Error::SerializeError(err.to_string()))?
+            .into();
+        state_selections.set_attribute(create_oxvg_attr(StateElement::SELECTION_IDS, selections));
+        self.effect_state(StateEffect::Embed)
+    }
+
+    /// Must be called at the end of an action. For an action that affects selection, must
+    /// be called after [`Actor::effect_selection`].
+    pub(crate) fn effect_tree(&mut self) -> Result<(), Error<'input>> {
+        let Some(selection) = self.get_selections_list()? else {
+            self.allocator.reorder(self.root);
+            return Ok(());
+        };
+
+        #[allow(clippy::cast_sign_loss)]
+        let selections: Vec<_> = selection
+            .list
+            .into_iter()
+            .filter_map(|i| self.allocator.get(i as usize))
+            .collect();
+        self.allocator.reorder(self.root);
+        #[allow(clippy::cast_possible_wrap)]
+        self.effect_selection(&selections.into_iter().map(|n| n.id() as Integer).collect())
+    }
+}

--- a/crates/oxvg_actions/src/lib.rs
+++ b/crates/oxvg_actions/src/lib.rs
@@ -4,6 +4,7 @@ Similar to Inkscape's actions, can be used to manipulate a document through a CL
 As a library, actions can be used to dispatch changes to a document from an editor.
 */
 mod actions;
+mod effects;
 mod error;
 pub(crate) mod info;
 pub(crate) mod state;

--- a/crates/oxvg_actions/src/spec/structure/insert.md
+++ b/crates/oxvg_actions/src/spec/structure/insert.md
@@ -1,0 +1,8 @@
+Creates a new SVG element and inserts it into the current selection. Selects the new elements. Has no effect if the parent doesn't accept the tag as a child of it's [content-model](https://svgwg.org/svg2-draft/eltindex.html).
+
+```sh
+# Effects: history, document, selection, tree
+-insert "<qual-name>"
+# Alias
+-create-element "<qual-name>"
+```

--- a/crates/oxvg_actions/src/state.rs
+++ b/crates/oxvg_actions/src/state.rs
@@ -84,19 +84,19 @@ impl<'input, 'arena> State<'input, 'arena> {
         let document = element.as_document();
         let state_element = element
             .last_element_child()
-            .filter(|e| assert_oxvg_element(e, StateElement::STATE).is_ok())
+            .filter(|e| assert_oxvg_element(*e, StateElement::STATE).is_ok())
             .unwrap_or_else(|| {
                 document.create_element(create_oxvg_element(StateElement::STATE), allocator)
             });
         let mut state = Self {
-            state: state_element.clone(),
+            state: state_element,
             history: None,
             selection: None,
         };
 
         state_element.remove();
         for element in state_element.children_iter() {
-            state.debed_field(&element)?;
+            state.debed_field(element)?;
         }
 
         Ok(state)
@@ -134,17 +134,17 @@ impl<'input, 'arena> State<'input, 'arena> {
         Ok(())
     }
 
-    fn debed_field(&mut self, element: &Element<'input, 'arena>) -> Result<(), Error<'input>> {
+    fn debed_field(&mut self, element: Element<'input, 'arena>) -> Result<(), Error<'input>> {
         let name = element.qual_name();
         assert_oxvg_xmlns(name.prefix())?;
 
         let field = StateElement::try_from(name.local_name().clone())?;
         match field {
             StateElement::History => {
-                self.history = Some(element.clone());
+                self.history = Some(element);
             }
             StateElement::Selection => {
-                self.selection = Some(element.clone());
+                self.selection = Some(element);
             }
         }
         Ok(())
@@ -152,22 +152,22 @@ impl<'input, 'arena> State<'input, 'arena> {
 
     pub fn record(&mut self, action: &Action<'input>, allocator: &Allocator<'input, 'arena>) {
         let history = self.get_history(allocator);
-        action.embed(&history, allocator);
+        action.embed(history, allocator);
     }
 
     pub fn get_selections(
         &mut self,
         allocator: &Allocator<'input, 'arena>,
     ) -> Element<'input, 'arena> {
-        if let Some(e) = &self.selection {
-            e.clone()
+        if let Some(e) = self.selection {
+            e
         } else {
             let selection = self
                 .state
                 .as_document()
                 .create_element(create_oxvg_element(StateElement::SELECTION), allocator);
             self.state.append_child(*selection);
-            self.selection = Some(selection.clone());
+            self.selection = Some(selection);
             selection
         }
     }
@@ -177,14 +177,14 @@ impl<'input, 'arena> State<'input, 'arena> {
         allocator: &Allocator<'input, 'arena>,
     ) -> Element<'input, 'arena> {
         if let Some(e) = &self.history {
-            e.clone()
+            *e
         } else {
             let history = self
                 .state
                 .as_document()
                 .create_element(create_oxvg_element(StateElement::HISTORY), allocator);
             self.state.append_child(*history);
-            self.history = Some(history.clone());
+            self.history = Some(history);
             history
         }
     }
@@ -213,7 +213,7 @@ impl<'input, 'arena> DerivedState<'input> {
                 .history
                 .iter()
                 .flat_map(Element::children_iter)
-                .map(|e| Action::from_state(&e))
+                .map(Action::from_state)
                 .collect::<Result<Vec<_>, _>>()?,
             info: Info::new(&selection, allocator)?,
             selection,
@@ -251,20 +251,21 @@ impl<'input> Action<'input> {
     const ROTATE: &'static str = "Rotate";
     const SKEW_X: &'static str = "SkewX";
     const SKEW_Y: &'static str = "SkewY";
+    const INSERT: &'static str = "Insert";
     const FORGET: &'static str = "Forget";
     const SELECT: &'static str = "Select";
     const SELECT_MORE: &'static str = "SelectMore";
     const DESELECT: &'static str = "Deselect";
 
     #[allow(clippy::too_many_lines, clippy::many_single_char_names)]
-    fn from_state(element: &Element<'input, '_>) -> Result<Self, Error<'input>> {
+    fn from_state(element: Element<'input, '_>) -> Result<Self, Error<'input>> {
         assert_oxvg_element(element, Self::ACTION)?;
 
-        let Some(id) = get_oxvg_attr(element, Self::ID)? else {
+        let Some(id) = get_oxvg_attr(&element, Self::ID)? else {
             return Err(Error::MissingStateAttribute(Self::ID));
         };
         let mut args = element.children_iter().map(|child| {
-            assert_oxvg_element(&child, Self::ARG)?;
+            assert_oxvg_element(child, Self::ARG)?;
             Ok(child.text_content().unwrap_or_default())
         });
         let n_args = |value: Result<Atom<'input>, Error<'input>>| {
@@ -373,6 +374,7 @@ impl<'input> Action<'input> {
                 };
                 Ok(Self::SkewY(y))
             }
+            Self::FORGET => Ok(Self::Forget),
             Self::SELECT => {
                 let Some(string) = args.next().transpose()? else {
                     return Err(Error::MissingStateAttribute(Self::ARG));
@@ -385,6 +387,7 @@ impl<'input> Action<'input> {
                 };
                 Ok(Self::SelectMore(string))
             }
+            Self::DESELECT => Ok(Self::Deselect),
             _ => Err(Error::InvalidStateAttribute(id.clone())),
         }
     }
@@ -392,7 +395,7 @@ impl<'input> Action<'input> {
     #[allow(clippy::many_single_char_names)]
     fn embed<'arena>(
         &self,
-        parent: &Element<'input, 'arena>,
+        parent: Element<'input, 'arena>,
         allocator: &Allocator<'input, 'arena>,
     ) {
         let document = parent.as_document();
@@ -410,35 +413,35 @@ impl<'input> Action<'input> {
                 property: arg0,
                 value: arg1,
             } => {
-                Self::embed_arg(&element, allocator, arg0.clone());
-                Self::embed_arg(&element, allocator, arg1.clone());
+                Self::embed_arg(element, allocator, arg0.clone());
+                Self::embed_arg(element, allocator, arg1.clone());
             }
             Self::Matrix(a, b, c, d, e, f) => {
-                Self::embed_arg(&element, allocator, a.to_string().into());
-                Self::embed_arg(&element, allocator, b.to_string().into());
-                Self::embed_arg(&element, allocator, c.to_string().into());
-                Self::embed_arg(&element, allocator, d.to_string().into());
-                Self::embed_arg(&element, allocator, e.to_string().into());
-                Self::embed_arg(&element, allocator, f.to_string().into());
+                Self::embed_arg(element, allocator, a.to_string().into());
+                Self::embed_arg(element, allocator, b.to_string().into());
+                Self::embed_arg(element, allocator, c.to_string().into());
+                Self::embed_arg(element, allocator, d.to_string().into());
+                Self::embed_arg(element, allocator, e.to_string().into());
+                Self::embed_arg(element, allocator, f.to_string().into());
             }
             Self::Translate(x, y) | Self::Scale(x, y) => {
-                Self::embed_arg(&element, allocator, x.to_string().into());
+                Self::embed_arg(element, allocator, x.to_string().into());
                 if let Some(y) = y {
-                    Self::embed_arg(&element, allocator, y.to_string().into());
+                    Self::embed_arg(element, allocator, y.to_string().into());
                 }
             }
             Self::Rotate(angle, origin) => {
-                Self::embed_arg(&element, allocator, angle.to_string().into());
+                Self::embed_arg(element, allocator, angle.to_string().into());
                 if let Some((x, y)) = origin {
-                    Self::embed_arg(&element, allocator, x.to_string().into());
-                    Self::embed_arg(&element, allocator, y.to_string().into());
+                    Self::embed_arg(element, allocator, x.to_string().into());
+                    Self::embed_arg(element, allocator, y.to_string().into());
                 }
             }
             Self::SkewX(arg) | Self::SkewY(arg) => {
-                Self::embed_arg(&element, allocator, arg.to_string().into());
+                Self::embed_arg(element, allocator, arg.to_string().into());
             }
-            Self::Class(arg) | Self::Select(arg) | Self::SelectMore(arg) => {
-                Self::embed_arg(&element, allocator, arg.clone());
+            Self::Class(arg) | Self::Select(arg) | Self::SelectMore(arg) | Self::Insert(arg) => {
+                Self::embed_arg(element, allocator, arg.clone());
             }
             Self::PathIntersect
             | Self::PathUnion
@@ -450,7 +453,7 @@ impl<'input> Action<'input> {
     }
 
     fn embed_arg<'arena>(
-        parent: &Element<'input, 'arena>,
+        parent: Element<'input, 'arena>,
         allocator: &Allocator<'input, 'arena>,
         arg_atom: Atom<'input>,
     ) {
@@ -475,6 +478,7 @@ impl<'input> Action<'input> {
             Self::Rotate(..) => Self::ROTATE,
             Self::SkewX(_) => Self::SKEW_X,
             Self::SkewY(_) => Self::SKEW_Y,
+            Self::Insert(_) => Self::INSERT,
             Self::Forget => Self::FORGET,
             Self::Select(_) => Self::SELECT,
             Self::SelectMore(_) => Self::SELECT_MORE,
@@ -510,6 +514,7 @@ impl<'input> Action<'input> {
             }
             Self::SkewX(x) => ActionNapi::SkewX(*x as f64),
             Self::SkewY(y) => ActionNapi::SkewY(*y as f64),
+            Self::Insert(name) => ActionNapi::Insert(name.to_string()),
             Self::Forget => ActionNapi::Forget,
             Self::Select(query) => ActionNapi::Select(query.to_string()),
             Self::SelectMore(query) => ActionNapi::SelectMore(query.to_string()),
@@ -545,6 +550,7 @@ impl<'input> Action<'input> {
             }
             ActionNapi::SkewX(x) => Action::SkewX(x as f32),
             ActionNapi::SkewY(y) => Action::SkewY(y as f32),
+            ActionNapi::Insert(name) => Action::Insert(name.into()),
             ActionNapi::Forget => Action::Forget,
             ActionNapi::Select(query) => Action::Select(query.into()),
             ActionNapi::SelectMore(query) => Action::SelectMore(query.into()),

--- a/crates/oxvg_actions/src/utils.rs
+++ b/crates/oxvg_actions/src/utils.rs
@@ -5,10 +5,10 @@ use oxvg_collections::{
     atom::Atom,
     attribute::{Attr, AttrId},
     element::ElementId,
-    name::{Prefix, QualName, NS},
+    name::{NS, Prefix, QualName},
 };
 
-use crate::{error::Error, OXVG_PREFIX, OXVG_XMLNS};
+use crate::{OXVG_PREFIX, OXVG_XMLNS, error::Error};
 
 pub fn is_oxvg_xmlns(prefix: &Prefix) -> bool {
     matches!(
@@ -28,7 +28,7 @@ pub fn assert_oxvg_xmlns(prefix: &Prefix) -> Result<(), Error<'static>> {
 }
 
 pub fn assert_oxvg_element<'input>(
-    element: &Element<'input, '_>,
+    element: Element<'input, '_>,
     local_name: &str,
 ) -> Result<(), Error<'input>> {
     let name = element.qual_name();

--- a/crates/oxvg_ast/src/arena.rs
+++ b/crates/oxvg_ast/src/arena.rs
@@ -1,6 +1,8 @@
 //! The arena used to allocate nodes
 use std::cell::RefCell;
 
+use itertools::Itertools;
+
 use crate::node::{AllocationID, Node, NodeData, Ref};
 
 /// The inner value of [`Arena`]
@@ -122,7 +124,7 @@ impl<'input, 'arena> Allocator<'input, 'arena> {
             node.id.set(len);
         }
         // Assign ids in order to tree
-        let tree_len = Self::reorder_internal(root, 0);
+        let tree_len = Self::reorder_internal(root, 0) + 1;
         // Reassign ids in order outside of tree
         let mut index = tree_len;
         for node in self {
@@ -132,6 +134,7 @@ impl<'input, 'arena> Allocator<'input, 'arena> {
             }
         }
         // Sort by id
+        debug_assert!(self.iter().map(Node::id).all_unique());
         self.indices.borrow_mut().sort_by(|&a, &b| {
             let a: Ref<'input, 'arena> = unsafe { &*a };
             let b: Ref<'input, 'arena> = unsafe { &*b };
@@ -141,11 +144,17 @@ impl<'input, 'arena> Allocator<'input, 'arena> {
     }
 
     fn reorder_internal(node: Ref<'input, 'arena>, mut id: usize) -> usize {
-        debug_assert!(node.id.get() <= id, "cannot reorder tree with cycles");
+        debug_assert!(id <= node.id.get(), "cannot reorder tree with cycles");
         node.id.set(id);
-        id += 1;
-        for node in node.child_nodes_iter() {
-            id = Self::reorder_internal(node, id);
+        // for node in node.child_nodes_iter() {
+        //     id = Self::reorder_internal(node, id + 1);
+        // }
+        if let Some(mut child) = node.first_child() {
+            id = Self::reorder_internal(child, id + 1);
+            while let Some(sibling) = child.next_sibling() {
+                child = sibling;
+                id = Self::reorder_internal(child, id + 1);
+            }
         }
         id
     }

--- a/crates/oxvg_ast/src/element.rs
+++ b/crates/oxvg_ast/src/element.rs
@@ -11,7 +11,7 @@ use oxvg_collections::{
     atom::Atom,
     attribute::{Attr, AttrId},
     element::ElementId,
-    name::{Prefix, QualName, NS},
+    name::{NS, Prefix, QualName},
 };
 
 use crate::{
@@ -38,7 +38,7 @@ macro_rules! is_element {
     };
 }
 
-#[derive(Clone, Eq)]
+#[derive(Clone, Copy, Eq)]
 /// An XML element type.
 #[repr(transparent)]
 pub struct Element<'input, 'arena>(pub Ref<'input, 'arena>);
@@ -95,7 +95,7 @@ impl<'input, 'arena> Element<'input, 'arena> {
         );
 
         let uri = prefix.ns().uri();
-        let mut container = Some(self.clone());
+        let mut container = Some(*self);
         let mut matching_prefix = None;
         while let Some(inner) = container {
             container = inner.parent_element();
@@ -127,7 +127,7 @@ impl<'input, 'arena> Element<'input, 'arena> {
     /// For a given prefix name, finds the namespace URI that the given prefix belongs to be searching for
     /// the closest matching `xmlns` attribute.
     pub fn find_xmlns(&self, prefix: Option<&str>) -> Atom<'input> {
-        let mut container = Some(self.clone());
+        let mut container = Some(*self);
         while let Some(inner) = container {
             container = inner.parent_element();
 
@@ -147,9 +147,10 @@ impl<'input, 'arena> Element<'input, 'arena> {
                         value,
                     } => {
                         if let Some(prefix) = prefix
-                            && prefix == local.as_str() {
-                                return value.clone();
-                            }
+                            && prefix == local.as_str()
+                        {
+                            return value.clone();
+                        }
                     }
                     _ => (),
                 }
@@ -191,7 +192,7 @@ impl<'input, 'arena> Element<'input, 'arena> {
     ///
     /// For other cases, try [`Element::document`]
     pub fn as_document(&self) -> Document<'input, 'arena> {
-        Document(self.clone())
+        Document(*self)
     }
 
     /// Creates an element from an element's parent type.

--- a/crates/oxvg_ast/src/selectors.rs
+++ b/crates/oxvg_ast/src/selectors.rs
@@ -247,7 +247,7 @@ impl<'input, 'arena> Select<'input, 'arena> {
     ) -> Select<'input, 'arena> {
         Select {
             inner: element.breadth_first(),
-            scope: Some(element.clone()),
+            scope: Some(*element),
             selector,
             selector_caches: SelectorCaches::default(),
         }
@@ -261,9 +261,9 @@ impl<'input, 'arena> Iterator for Select<'input, 'arena> {
         self.inner.find(|element| {
             self.selector.matches_with_scope_and_cache(
                 &SelectElement {
-                    element: element.clone(),
+                    element: *element,
                 },
-                self.scope.clone(),
+                self.scope,
                 &mut self.selector_caches,
             )
         })

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -130,7 +130,7 @@ pub struct ComputedStyles<'input> {
 
 /// Gathers `<style>` declarations from the document
 pub fn root<'input, 'arena>(
-    root: &Element<'input, 'arena>,
+    root: Element<'input, 'arena>,
 ) -> impl Iterator<Item = RefCell<CssRuleList<'input>>> + use<'input, 'arena> {
     root.breadth_first()
         .filter_map(|node| node.first_child())
@@ -180,7 +180,7 @@ impl<'input> ComputedStyles<'input> {
     /// When styles contain bad selectors
     pub fn with_all(
         self,
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         styles: &[RefCell<CssRuleList<'input>>],
     ) -> Result<ComputedStyles<'input>, ComputedStylesError<'input>> {
         self.with_inline_style(element)
@@ -196,16 +196,16 @@ impl<'input> ComputedStyles<'input> {
     /// When styles contain bad selectors
     pub fn with_inherited(
         mut self,
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         styles: &[RefCell<CssRuleList<'input>>],
     ) -> Result<ComputedStyles<'input>, ComputedStylesError<'input>> {
-        let Some(parent) = Element::parent_element(element) else {
+        let Some(parent) = Element::parent_element(&element) else {
             return Ok(self);
         };
         if parent.node_type() == node::Type::Document {
             return Ok(self);
         }
-        let parent_styles = ComputedStyles::default().with_all(&parent, styles)?;
+        let parent_styles = ComputedStyles::default().with_all(parent, styles)?;
         self.inherited.extend(parent_styles.inherited);
         self.inherited.extend(
             parent_styles
@@ -254,7 +254,7 @@ impl<'input> ComputedStyles<'input> {
     /// When styles contain bad selectors
     pub fn with_style(
         mut self,
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         styles: &[RefCell<CssRuleList<'input>>],
     ) -> Result<ComputedStyles<'input>, ComputedStylesError<'input>> {
         for css in styles {
@@ -268,7 +268,7 @@ impl<'input> ComputedStyles<'input> {
     /// Include a style within a style scope
     fn with_nested_style(
         &mut self,
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         style: &rules::CssRule<'input>,
         selector: &mut Vec<String>,
         specificity: u32,
@@ -293,7 +293,7 @@ impl<'input> ComputedStyles<'input> {
                             selector: r.selectors.clone(),
                         }
                     })?;
-                    if !select.matches_naive(&SelectElement::new(element.clone())) {
+                    if !select.matches_naive(&SelectElement::new(element)) {
                         continue;
                     }
                     self.add_declarations(&r.declarations, specificity + s.specificity(), mode);
@@ -313,7 +313,7 @@ impl<'input> ComputedStyles<'input> {
     }
 
     /// Include styles from a presentable attribute
-    fn with_attribute(self, element: &Element<'input, '_>) -> ComputedStyles<'input> {
+    fn with_attribute(self, element: Element<'input, '_>) -> ComputedStyles<'input> {
         let attr = element
             .attributes()
             .into_iter()
@@ -327,7 +327,7 @@ impl<'input> ComputedStyles<'input> {
         ComputedStyles { attr, ..self }
     }
 
-    fn with_inline_style(self, element: &Element<'input, '_>) -> ComputedStyles<'input> {
+    fn with_inline_style(self, element: Element<'input, '_>) -> ComputedStyles<'input> {
         let Some(style) = get_attribute_mut!(element, Style) else {
             return self;
         };

--- a/crates/oxvg_ast/src/visitor.rs
+++ b/crates/oxvg_ast/src/visitor.rs
@@ -70,13 +70,13 @@ impl<'input, 'arena, 'i> Context<'input, 'arena, 'i> {
     }
 
     /// Queries whether a `<script>` element is within the document
-    pub fn query_has_script(&mut self, root: &Element<'_, '_>) {
+    pub fn query_has_script(&mut self, root: Element<'_, '_>) {
         self.flags
             .set(ContextFlags::query_has_script_result, has_scripts(root));
     }
 
     /// Queries whether a `<style>` element is within the document
-    pub fn query_has_stylesheet(&mut self, root: &Element<'input, '_>) {
+    pub fn query_has_stylesheet(&mut self, root: Element<'input, '_>) {
         self.query_has_stylesheet_result = style::root(root).collect();
         self.flags.set(
             ContextFlags::query_has_stylesheet_result,
@@ -137,7 +137,7 @@ pub trait Visitor<'input, 'arena> {
     /// Whether the visitor fails
     fn document(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -149,7 +149,7 @@ pub trait Visitor<'input, 'arena> {
     /// Whether the visitor fails
     fn exit_document(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -161,7 +161,7 @@ pub trait Visitor<'input, 'arena> {
     /// Whether the visitor fails
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -173,7 +173,7 @@ pub trait Visitor<'input, 'arena> {
     /// Whether the visitor fails
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -230,7 +230,7 @@ pub trait Visitor<'input, 'arena> {
     /// Whether the visitor fails
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(PrepareOutcome::none)
@@ -262,7 +262,7 @@ pub trait Visitor<'input, 'arena> {
             return Ok(PrepareOutcome::none);
         };
         self.start_with_info(
-            &root,
+            root,
             &Info {
                 path,
                 multipass_count: 0,
@@ -278,12 +278,12 @@ pub trait Visitor<'input, 'arena> {
     /// If any of the visitor's methods fail
     fn start_with_info(
         &self,
-        root: &Element<'input, 'arena>,
+        root: Element<'input, 'arena>,
         info: &Info<'input, 'arena>,
         flags: Option<ContextFlags>,
     ) -> Result<PrepareOutcome, Self::Error> {
         let flags = flags.unwrap_or_default();
-        let mut context = Context::new(root.clone(), flags, info);
+        let mut context = Context::new(root, flags, info);
         self.start_with_context(root, &mut context)
     }
 
@@ -293,7 +293,7 @@ pub trait Visitor<'input, 'arena> {
     /// If any of the visitor's methods fail
     fn start_with_context(
         &self,
-        root: &Element<'input, 'arena>,
+        root: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         let prepare_outcome = self.prepare(root, context)?;
@@ -311,7 +311,7 @@ pub trait Visitor<'input, 'arena> {
     /// If any of the visitor's methods fail
     fn visit(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         match element.node_type() {
@@ -354,7 +354,7 @@ pub trait Visitor<'input, 'arena> {
     /// If any of the visitor's methods fail
     fn visit_children(
         &self,
-        parent: &Element<'input, 'arena>,
+        parent: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         parent
@@ -362,7 +362,7 @@ pub trait Visitor<'input, 'arena> {
             .try_for_each(|child| match child.node_type() {
                 node::Type::Document | node::Type::Element => {
                     if let Some(child) = Element::new(child) {
-                        self.visit(&child, context)
+                        self.visit(child, context)
                     } else {
                         Ok(())
                     }
@@ -383,7 +383,7 @@ pub trait Visitor<'input, 'arena> {
 /// - A `<script>` element
 /// - An `onbegin`, `onend`, `on...`, etc. attribute
 /// - A `href="javascript:..."` URL
-pub fn has_scripts(root: &Element<'_, '_>) -> bool {
+pub fn has_scripts(root: Element<'_, '_>) -> bool {
     use oxvg_collections::attribute::{Attr, AttributeGroup};
 
     let event = AttributeGroup::event();

--- a/crates/oxvg_collections/src/attribute/list_of.rs
+++ b/crates/oxvg_collections/src/attribute/list_of.rs
@@ -2,20 +2,20 @@
 use std::ops::Deref;
 
 #[cfg(feature = "parse")]
-use oxvg_parse::{error::Error, Parse, Parser};
+use oxvg_parse::{Parse, Parser, error::Error};
 #[cfg(feature = "serialize")]
-use oxvg_serialize::{error::PrinterError, Printer, ToValue};
+use oxvg_serialize::{Printer, ToValue, error::PrinterError};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 /// A `' '` delimiter
 pub struct Space;
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 /// A `','` delimiter
 pub struct Comma;
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 /// A `' '` or `','` delimiter
 pub struct SpaceOrComma;
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 /// A `';'` delimiter
 pub struct Semicolon;
 
@@ -205,6 +205,37 @@ pub struct ListOf<T: std::fmt::Debug + PartialEq, S: Separator> {
     pub separator: S,
 }
 
+impl<T: std::fmt::Debug + PartialEq, S: Separator + Default> Default for ListOf<T, S> {
+    fn default() -> Self {
+        Self {
+            list: Vec::default(),
+            separator: S::default(),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug + PartialEq, S: Separator + Default> From<Vec<T>> for ListOf<T, S> {
+    fn from(value: Vec<T>) -> Self {
+        Self {
+            list: value,
+            separator: S::default(),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug + PartialEq, S: Separator + Default> From<T> for ListOf<T, S> {
+    /// Converts to [`ListOf`] containing a single item of the input type.
+    fn from(value: T) -> Self {
+        vec![value].into()
+    }
+}
+
+impl<T: std::fmt::Debug + PartialEq, S: Separator + Default> FromIterator<T> for ListOf<T, S> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Vec::from_iter(iter).into()
+    }
+}
+
 impl<T: Clone + std::fmt::Debug + PartialEq, S: Separator> Clone for ListOf<T, S> {
     fn clone(&self) -> Self {
         Self {
@@ -254,7 +285,7 @@ impl<'input, T: Parse<'input> + std::fmt::Debug + PartialEq, S: Separator> Parse
                 return Ok(Self {
                     list: vec![],
                     separator: S::new(),
-                })
+                });
             }
             Err(e) => return Err(e),
         };

--- a/crates/oxvg_lint/src/rules/mod.rs
+++ b/crates/oxvg_lint/src/rules/mod.rs
@@ -102,7 +102,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Rules {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_script(document);
@@ -133,10 +133,10 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Reporter<'_, 'input> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
-        let mut rule_data = RuleData::new(element, self.reports.borrow_mut());
+        let mut rule_data = RuleData::new(&element, self.reports.borrow_mut());
 
         match &self.rules.no_unknown_elements {
             Severity::Off => {}
@@ -172,7 +172,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Reporter<'_, 'input> {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut reports = self.reports.borrow_mut();
@@ -195,7 +195,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Reporter<'_, 'input> {
 
     fn exit_document(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if context
@@ -233,7 +233,7 @@ impl<'i> lightningcss::visitor::Visitor<'i> for Reporter<'_, '_> {
     }
 }
 impl<'input> Reporter<'_, 'input> {
-    fn track_id_references(&self, element: &Element<'input, '_>) {
+    fn track_id_references(&self, element: Element<'input, '_>) {
         let mut referenced_ids = self.referenced_ids.borrow_mut();
         let attribute_ranges = element.attribute_ranges();
         for mut attribute in element.attributes().into_iter_mut() {
@@ -254,7 +254,7 @@ impl<'input> Reporter<'_, 'input> {
         }
     }
 
-    fn push_xmlns(&self, element: &Element<'input, '_>) {
+    fn push_xmlns(&self, element: Element<'input, '_>) {
         let mut namespaces = HashSet::new();
         for attr in element.attributes() {
             match &*attr {
@@ -276,7 +276,7 @@ impl<'input> Reporter<'_, 'input> {
         }
         self.xmlns_stack.borrow_mut().push(namespaces);
     }
-    fn track_xmlns(&self, element: &Element<'input, '_>) {
+    fn track_xmlns(&self, element: Element<'input, '_>) {
         let mut xmlns_stack = self.xmlns_stack.borrow_mut();
         let insert = |xmlns_stack: &mut NamespaceStack<'input>,
                       name: Option<Atom<'input>>,

--- a/crates/oxvg_optimiser/src/jobs/add_attributes_to_s_v_g_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/add_attributes_to_s_v_g_element.rs
@@ -72,7 +72,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for AddAttributesToSVGElement {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !element.is_root() || !is_element!(element, Svg) {

--- a/crates/oxvg_optimiser/src/jobs/add_classes_to_s_v_g_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/add_classes_to_s_v_g_element.rs
@@ -87,7 +87,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for AddClassesToSVGElement {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !element.is_root() || !is_element!(element, Svg) {

--- a/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
+++ b/crates/oxvg_optimiser/src/jobs/apply_transforms.rs
@@ -67,7 +67,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ApplyTransforms {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -77,7 +77,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ApplyTransforms {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !has_attribute!(element, D) {
@@ -190,7 +190,7 @@ impl ApplyTransforms {
         matrix: &[f64; 6],
         stroke: &SVGPaint,
         stroke_width: Option<Inheritable<LengthPercentage>>,
-        element: &Element,
+        element: Element,
     ) -> bool {
         if matches!(stroke, SVGPaint::None) {
             return false;

--- a/crates/oxvg_optimiser/src/jobs/cleanup_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_attrs.rs
@@ -51,7 +51,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupAttrs {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         for mut attr in element.attributes().into_iter_mut() {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_enable_background.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_enable_background.rs
@@ -1,8 +1,8 @@
 use lightningcss::{
     declaration::DeclarationBlock,
     properties::{
-        custom::{CustomProperty, Token, TokenOrValue},
         Property,
+        custom::{CustomProperty, Token, TokenOrValue},
     },
     values::percentage::DimensionPercentage,
     visit_types,
@@ -66,14 +66,14 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupEnableBackground {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if !self.0 {
             return Ok(PrepareOutcome::skip);
         }
         if let Some(root) = document.find_element() {
-            State::new(&root).start_with_context(document, context)?;
+            State::new(root).start_with_context(document, context)?;
         }
         Ok(PrepareOutcome::skip)
     }
@@ -110,7 +110,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let style = get_attribute_mut!(element, Style);
@@ -182,7 +182,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State {
 }
 
 impl State {
-    fn new(root: &Element) -> Self {
+    fn new(root: Element) -> Self {
         Self {
             contains_filter: root
                 .breadth_first()

--- a/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_ids.rs
@@ -9,7 +9,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::{
-    attribute::{core_attrs::NonWhitespace, Attr, AttrId},
+    attribute::{Attr, AttrId, core_attrs::NonWhitespace},
     content_type::Reference,
 };
 #[cfg(feature = "serde")]
@@ -105,7 +105,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupIds {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -133,7 +133,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if self.ignore_document {
@@ -146,7 +146,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
         let mut track_reference = |reference: &str, attr: &AttrId<'input>| {
             if self.replaceable_ids.contains(reference) {
                 ref_renames.push(RefRename {
-                    element_ref: element.clone(),
+                    element_ref: element,
                     name: attr.clone(),
                     referenced_id: reference.to_string(),
                 });
@@ -174,7 +174,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn exit_document(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         _context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let remove = self.options.remove;
@@ -260,9 +260,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
                 }
             });
         }
-        log::debug!(
-            "CleanupIds::breakdown: replacing: {minified_ids:#?} <-> {used_ids:#?}",
-        );
+        log::debug!("CleanupIds::breakdown: replacing: {minified_ids:#?} <-> {used_ids:#?}");
         if remove {
             for element in root.breadth_first() {
                 element.attributes().retain(|attr| {
@@ -281,7 +279,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 impl<'input, 'arena> State<'_, 'input, 'arena> {
     fn prepare_ignore_document(
         &self,
-        root: &Element<'input, 'arena>,
+        root: Element<'input, 'arena>,
         context_flags: &ContextFlags,
     ) -> bool {
         if self.options.force {
@@ -299,7 +297,7 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
     /// Prepares tracking of ids for removal/renaming
     /// - Adds non-preserved ids to `self.replaceable_ids`
     /// - Removes any duplicate replaceable ids
-    fn prepare_id_rename(&mut self, root: &Element<'input, 'arena>) {
+    fn prepare_id_rename(&mut self, root: Element<'input, 'arena>) {
         let mut preserved_ids = Vec::new();
         log::debug!(
             "CleanupIds: prepare_id: preserve: {:#?} <-> {:#?}",

--- a/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_list_of_values.rs
@@ -52,7 +52,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupListOfValues {
 
     fn document(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if self.float_precision > 5 {
@@ -64,7 +64,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupListOfValues {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         element.attributes().into_iter_mut().for_each(|mut attr| {

--- a/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
+++ b/crates/oxvg_optimiser/src/jobs/cleanup_numeric_values.rs
@@ -52,7 +52,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupNumericValues {
 
     fn document(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if self.float_precision > 5 {
@@ -64,7 +64,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CleanupNumericValues {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         element.attributes().into_iter_mut().for_each(|mut attr| {

--- a/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
+++ b/crates/oxvg_optimiser/src/jobs/collapse_groups.rs
@@ -8,7 +8,7 @@ use oxvg_ast::{
 };
 use oxvg_collections::{
     atom::Atom,
-    attribute::{inheritable::Inheritable, Attr},
+    attribute::{Attr, inheritable::Inheritable},
     content_type::ContentType,
     element::ElementCategory,
 };
@@ -45,7 +45,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CollapseGroups {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -57,10 +57,10 @@ impl<'input, 'arena> Visitor<'input, 'arena> for CollapseGroups {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
-        let Some(parent) = Element::parent_element(element) else {
+        let Some(parent) = Element::parent_element(&element) else {
             return Ok(());
         };
 
@@ -83,7 +83,7 @@ impl Default for CollapseGroups {
     }
 }
 
-fn move_attributes_to_child(element: &Element) {
+fn move_attributes_to_child(element: Element) {
     log::debug!("collapse_groups: move_attributes_to_child");
 
     let mut children = element.children_iter();
@@ -102,10 +102,10 @@ fn move_attributes_to_child(element: &Element) {
         return;
     }
 
-    if is_group_identifiable(element, &first_child) {
+    if is_group_identifiable(element, first_child) {
         log::debug!("collapse_groups: not moving attrs: identifiable");
         return;
-    } else if is_position_visually_unstable(element, &first_child) {
+    } else if is_position_visually_unstable(element, first_child) {
         log::debug!("collapse_groups: not moving attrs: visually unstable");
         return;
     } else if is_node_with_filter(element) {
@@ -118,7 +118,7 @@ fn move_attributes_to_child(element: &Element) {
     for mut attr in attrs.into_iter_mut() {
         let name = attr.name().clone();
         let child_attr = first_child_attrs.get_named_item_mut(&name);
-        if has_animated_attr(&first_child, name.local_name()) {
+        if has_animated_attr(first_child, name.local_name()) {
             log::debug!("collapse_groups: canelled moves: has animated_attr");
             return;
         }
@@ -154,7 +154,7 @@ fn move_attributes_to_child(element: &Element) {
     }
 }
 
-fn flatten_when_all_attributes_moved(element: &Element) {
+fn flatten_when_all_attributes_moved(element: Element) {
     if !element.attributes().is_empty() {
         log::debug!("skipping flatten: has attributes");
         return;
@@ -175,8 +175,8 @@ fn flatten_when_all_attributes_moved(element: &Element) {
     element.flatten();
 }
 
-fn has_animated_attr<'input>(element: &Element<'input, '_>, local_name: &Atom<'input>) -> bool {
-    for child in std::iter::once(element.clone()).chain(element.breadth_first()) {
+fn has_animated_attr<'input>(element: Element<'input, '_>, local_name: &Atom<'input>) -> bool {
+    for child in std::iter::once(element).chain(element.breadth_first()) {
         if child
             .qual_name()
             .categories()
@@ -190,22 +190,22 @@ fn has_animated_attr<'input>(element: &Element<'input, '_>, local_name: &Atom<'i
 }
 
 fn is_group_identifiable<'input, 'arena>(
-    node: &Element<'input, 'arena>,
-    child: &Element<'input, 'arena>,
+    node: Element<'input, 'arena>,
+    child: Element<'input, 'arena>,
 ) -> bool {
     has_attribute!(child, Id) && (!has_attribute!(node, Class) || !has_attribute!(child, Class))
 }
 
 fn is_position_visually_unstable<'input, 'arena>(
-    node: &Element<'input, 'arena>,
-    child: &Element<'input, 'arena>,
+    node: Element<'input, 'arena>,
+    child: Element<'input, 'arena>,
 ) -> bool {
     let is_node_clipping = has_attribute!(node, ClipPath | Mask);
     let is_child_transformed_group = is_element!(child, G) && has_attribute!(child, Transform);
     is_node_clipping || is_child_transformed_group
 }
 
-fn is_node_with_filter(node: &Element) -> bool {
+fn is_node_with_filter(node: Element) -> bool {
     has_attribute!(node, Filter)
         || get_attribute!(node, Style)
             .is_some_and(|style| style.get(&PropertyId::Filter(VendorPrefix::None)).is_some())

--- a/crates/oxvg_optimiser/src/jobs/convert_colors.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_colors.rs
@@ -7,7 +7,7 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::{
-    attribute::{core_attrs::Style, Attr},
+    attribute::{Attr, core_attrs::Style},
     element::ElementId,
 };
 #[cfg(feature = "serde")]
@@ -74,7 +74,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertColors {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(match self.method {
@@ -91,7 +91,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertColors {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let is_masked = is_element!(element, Mask) || element.closest(&ElementId::Mask).is_some();

--- a/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_ellipse_to_circle.rs
@@ -38,7 +38,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertEllipseToCircle {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -51,7 +51,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertEllipseToCircle {
     #[allow(clippy::similar_names)]
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Ellipse) {

--- a/crates/oxvg_optimiser/src/jobs/convert_one_stop_gradients.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_one_stop_gradients.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use lightningcss::{
-    properties::{custom::TokenOrValue, Property},
+    properties::{Property, custom::TokenOrValue},
     values::url::Url,
     visit_types,
     visitor::Visit,
@@ -19,9 +19,9 @@ use oxvg_ast::{
 use oxvg_collections::{
     atom::Atom,
     attribute::{
+        Attr, AttrId,
         core_attrs::{Color, Paint},
         inheritable::Inheritable,
-        Attr, AttrId,
     },
     content_type::ContentType,
     name::{Prefix, QualName},
@@ -64,7 +64,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertOneStopGradients {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
@@ -79,7 +79,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -88,16 +88,14 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if has_attribute!(element, XLinkHref) {
             self.xlink_href_count.set(self.xlink_href_count.get() + 1);
         }
         if is_element!(element, Defs) {
-            self.all_defs
-                .borrow_mut()
-                .insert(element.id(), element.clone());
+            self.all_defs.borrow_mut().insert(element.id(), element);
             return Ok(());
         } else if !is_element!(element, LinearGradient | RadialGradient) {
             return Ok(());
@@ -115,20 +113,20 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
                         get_attribute!(element, Id).is_some_and(|id| id.0.as_str() == &href[1..])
                     })
                 } else {
-                    Some(element.clone())
+                    Some(element)
                 }
             } else {
-                Some(element.clone())
+                Some(element)
             }
         } else {
-            Some(element.clone())
+            Some(element)
         };
         drop(href);
 
         let mut gradients_to_detach = self.gradients_to_detach.borrow_mut();
         let Some(effective_node) = effective_node else {
             log::debug!("no effective nodes for gradient");
-            gradients_to_detach.insert(element.id(), element.clone());
+            gradients_to_detach.insert(element.id(), element);
             return Ok(());
         };
 
@@ -143,11 +141,12 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
         }
 
         if let Some(parent) = element.parent_element()
-            && is_element!(parent, Defs) {
-                self.effected_defs.borrow_mut().insert(parent.id(), parent);
-            }
+            && is_element!(parent, Defs)
+        {
+            self.effected_defs.borrow_mut().insert(parent.id(), parent);
+        }
 
-        gradients_to_detach.insert(element.id(), element.clone());
+        gradients_to_detach.insert(element.id(), element);
 
         let color = get_color(context, &effective_stops)?;
         let Some(id) = get_attribute!(element, Id) else {
@@ -164,7 +163,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Svg) {
@@ -203,18 +202,16 @@ fn get_color<'input, 'arena>(
 ) -> Result<Option<Color>, JobsError<'input>> {
     let effective_stop = effective_stops.first().expect("len should be 1");
     let computed_styles = ComputedStyles::default()
-        .with_all(effective_stop, &context.query_has_stylesheet_result)
+        .with_all(*effective_stop, &context.query_has_stylesheet_result)
         .map_err(JobsError::ComputedStylesError)?;
 
     if let Some((stop_color, Mode::Static)) = computed_styles.get(&AttrId::StopColor) {
         return Ok(match stop_color {
             Attr::StopColor(Inheritable::Defined(color)) => Some(color),
-            Attr::CSSUnknown { value, .. } => {
-                value.0 .0.into_iter().find_map(|token| match token {
-                    TokenOrValue::Color(color) => Some(color),
-                    _ => None,
-                })
-            }
+            Attr::CSSUnknown { value, .. } => value.0.0.into_iter().find_map(|token| match token {
+                TokenOrValue::Color(color) => Some(color),
+                _ => None,
+            }),
             _ => None,
         });
     }
@@ -235,9 +232,11 @@ fn update_color_references(context: &mut Context, color: &Color, url: &str) {
                 url: Url { url: attr_url, .. },
                 ..
             } = &mut *attr_color
-                && attr_url.starts_with('#') && &attr_url[1..] == url {
-                    *attr_color = Paint::Color(color.clone());
-                }
+                && attr_url.starts_with('#')
+                && &attr_url[1..] == url
+            {
+                *attr_color = Paint::Color(color.clone());
+            }
         }
     }
 }
@@ -261,9 +260,11 @@ impl<'i> lightningcss::visitor::Visitor<'i> for VisitPaint<'_> {
             url: Url { url, .. },
             ..
         } = paint
-            && url.starts_with('#') && &url[1..] == self.url {
-                *paint = Paint::Color(self.color.clone());
-            }
+            && url.starts_with('#')
+            && &url[1..] == self.url
+        {
+            *paint = Paint::Color(self.color.clone());
+        }
         Ok(())
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_path_data.rs
@@ -102,7 +102,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertPathData {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -112,7 +112,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertPathData {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !has_attribute!(element, D) {

--- a/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_shape_to_path.rs
@@ -7,13 +7,13 @@ use oxvg_ast::{
     visitor::{Context, Info, PrepareOutcome, Visitor},
 };
 use oxvg_collections::{
-    attribute::{path, presentation::LengthPercentage, uncategorised::Radius, AttrId},
+    attribute::{AttrId, path, presentation::LengthPercentage, uncategorised::Radius},
     element::ElementId,
 };
 use oxvg_path::{
+    Path,
     command::Data,
     geometry::{Tolerance, TolerancePrecision},
-    Path,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -72,7 +72,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertShapeToPath {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<oxvg_ast::visitor::PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -149,7 +149,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let name = element.qual_name();
@@ -210,7 +210,7 @@ fn r_px(r: cell::Ref<Radius>) -> Option<f64> {
 }
 impl ConvertShapeToPath {
     fn rect_to_path<'input, 'arena>(
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         precision: TolerancePrecision,
         info: &Info<'input, 'arena>,
     ) {
@@ -255,7 +255,7 @@ impl ConvertShapeToPath {
     }
 
     fn line_to_path<'input, 'arena>(
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         precision: TolerancePrecision,
         info: &Info<'input, 'arena>,
     ) {
@@ -299,7 +299,7 @@ impl ConvertShapeToPath {
     }
 
     fn poly_to_path<'input, 'arena>(
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         precision: TolerancePrecision,
         is_polygon: bool,
         info: &Info<'input, 'arena>,
@@ -309,7 +309,7 @@ impl ConvertShapeToPath {
             element.remove();
             return;
         };
-        let mut data = points.0 .0;
+        let mut data = points.0.0;
         if data.len() <= 1 {
             // Remove pointless data ;)
             element.remove();
@@ -327,7 +327,7 @@ impl ConvertShapeToPath {
 
     #[allow(clippy::similar_names)]
     fn circle_to_path<'input, 'arena>(
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         precision: TolerancePrecision,
         info: &Info<'input, 'arena>,
     ) {
@@ -371,7 +371,7 @@ impl ConvertShapeToPath {
 
     #[allow(clippy::similar_names)]
     fn ellipse_to_path<'input, 'arena>(
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         precision: TolerancePrecision,
         info: &Info<'input, 'arena>,
     ) {

--- a/crates/oxvg_optimiser/src/jobs/convert_style_to_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_style_to_attrs.rs
@@ -68,7 +68,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertStyleToAttrs {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let Some(mut styles_attr) = get_attribute_mut!(element, Style) else {

--- a/crates/oxvg_optimiser/src/jobs/convert_transform.rs
+++ b/crates/oxvg_optimiser/src/jobs/convert_transform.rs
@@ -7,10 +7,10 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::{
+    AttrId,
     core_attrs::SVGTransformList,
     inheritable,
     transform::{Precision, SVGTransform},
-    AttrId,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -86,7 +86,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertTransform {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_script(document);
@@ -95,7 +95,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ConvertTransform {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if let Some(transform) =
@@ -172,7 +172,7 @@ impl ConvertTransform {
         &self,
         mut transform: RefMut<SVGTransformList>,
         name: &AttrId,
-        element: &Element,
+        element: Element,
     ) {
         log::debug!("transform_attr: found {name} to transform");
 
@@ -185,11 +185,13 @@ impl ConvertTransform {
     }
 
     fn transform(&self, transform: &mut SVGTransformList) {
-        if self.collapse_into_one && transform.0.len() > 1
-            && let Some(matrix) = transform.to_matrix_2d() {
-                log::debug!("collapsing transform to matrix");
-                transform.0 = vec![SVGTransform::Matrix(matrix)];
-            }
+        if self.collapse_into_one
+            && transform.0.len() > 1
+            && let Some(matrix) = transform.to_matrix_2d()
+        {
+            log::debug!("collapsing transform to matrix");
+            transform.0 = vec![SVGTransform::Matrix(matrix)];
+        }
         log::debug!(r#"working with data "{transform:?}""#);
 
         self.convert_to_shorts(transform);

--- a/crates/oxvg_optimiser/src/jobs/inline_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/inline_styles.rs
@@ -229,7 +229,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for InlineStyles {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         State::new(self).start_with_context(document, context)?;
@@ -242,7 +242,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut referenced_ids = self.referenced_ids.borrow_mut();
@@ -265,10 +265,12 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
         }
 
         if let Some(style_type) = get_attribute!(element, TypeStyle)
-            && !style_type.is_empty() && style_type.as_str() != "text/css" {
-                log::debug!("Not merging style: unsupported type");
-                return Ok(());
-            }
+            && !style_type.is_empty()
+            && style_type.as_str() != "text/css"
+        {
+            log::debug!("Not merging style: unsupported type");
+            return Ok(());
+        }
 
         let Some(css) = element.first_child().and_then(Node::style) else {
             log::debug!("Not merging style: empty");
@@ -282,7 +284,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
         let mut find_removable_tokens = FindRemovableTokens::new(self.options);
         let css = &mut *css.borrow_mut();
-        if let Err(err) = find_removable_tokens.inline_rules(css, &context.root) {
+        if let Err(err) = find_removable_tokens.inline_rules(css, context.root) {
             log::debug!("Not merging style: {err}");
             return Ok(());
         }
@@ -303,7 +305,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
     #[allow(clippy::too_many_lines)]
     fn exit_document(
         &self,
-        _root: &Element<'input, 'arena>,
+        _root: Element<'input, 'arena>,
         _context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let dynamically_referenced = self.dynamically_referenced.borrow();
@@ -312,9 +314,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
         #[allow(clippy::mutable_key_type)]
         let grouping = inlined
             .iter()
-            .into_group_map_by(|RemovedToken { element, .. }| {
-                HashableElement::new(element.clone())
-            });
+            .into_group_map_by(|RemovedToken { element, .. }| HashableElement::new(*element));
         for (element, mut group) in grouping {
             group.sort_by_key(|a| a.specificity);
 
@@ -339,7 +339,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
             style_attr.0.visit(&mut InlinePresentationAttributes {
                 state: self,
-                element: (*element).clone(),
+                element: (*element),
             })?;
             if !style_attr.declarations.is_empty() || !style_attr.important_declarations.is_empty()
             {
@@ -384,14 +384,14 @@ impl<'o, 'input, 'arena> FindRemovableTokens<'o, 'input, 'arena> {
     fn inline_rules(
         &mut self,
         stylesheet: &mut CssRuleList<'input>,
-        root: &Element<'input, 'arena>,
+        root: Element<'input, 'arena>,
     ) -> Result<(), anyhow::Error> {
         // First pass to find dynamic tokens, which will skip inlining.
         stylesheet.visit(self)?;
         // Second pass will take matching selectors from the stylesheet
         let mut collect_matching_selectors = CollectMatchingSelectors {
             find_removable_tokens: self,
-            root: root.clone(),
+            root,
         };
         stylesheet.visit(&mut collect_matching_selectors)?;
 
@@ -557,7 +557,7 @@ impl<'input> visitor::Visitor<'input> for CollectMatchingSelectors<'_, '_, 'inpu
             };
             for m in matches {
                 self.find_removable_tokens.inlines.push(RemovedToken {
-                    element: m.clone(),
+                    element: m,
                     tokens: matching_tokens.clone(),
                     specificity: selector.specificity(),
                     declarations: declarations.clone(),

--- a/crates/oxvg_optimiser/src/jobs/merge_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_paths.rs
@@ -63,7 +63,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MergePaths {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -73,7 +73,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MergePaths {
     #[allow(clippy::too_many_lines)]
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut children = itertools::peek_nth(element.children_iter());
@@ -109,7 +109,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MergePaths {
                 continue;
             }
             let computed_styles = ComputedStyles::default()
-                .with_all(&child, &context.query_has_stylesheet_result)
+                .with_all(child, &context.query_has_stylesheet_result)
                 .map_err(JobsError::ComputedStylesError)?;
             let Some(mut current_path_data) =
                 get_attribute_mut!(child, D).map(|d| RefMut::map(d, |path::Path(d, _)| d))

--- a/crates/oxvg_optimiser/src/jobs/merge_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/merge_styles.rs
@@ -1,6 +1,6 @@
 use std::cell::{Cell, RefCell};
 
-use lightningcss::rules::{media::MediaRule, CssRule, CssRuleList, Location};
+use lightningcss::rules::{CssRule, CssRuleList, Location, media::MediaRule};
 use oxvg_ast::{
     element::Element,
     get_attribute, is_element,
@@ -48,7 +48,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MergeStyles {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
@@ -63,7 +63,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Style) {
@@ -71,10 +71,12 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
         }
 
         if let Some(style_type) = get_attribute!(element, TypeStyle)
-            && !style_type.is_empty() && &**style_type != "text/css" {
-                log::debug!("Not merging style: unsupported type");
-                return Ok(());
-            }
+            && !style_type.is_empty()
+            && &**style_type != "text/css"
+        {
+            log::debug!("Not merging style: unsupported type");
+            return Ok(());
+        }
 
         if context.flags.contains(ContextFlags::within_foreign_object) {
             log::debug!("Not merging style: foreign-object");
@@ -120,7 +122,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
         } else {
             drop(first_style);
             element.set_style_content(CssRuleList(css), &context.info.allocator);
-            self.first_style.replace(Some(element.clone()));
+            self.first_style.replace(Some(element));
             log::debug!("Assigned first style");
         }
         Ok(())
@@ -128,7 +130,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 
     fn exit_document(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &Context<'input, 'arena, '_>,
     ) -> Result<(), JobsError<'input>> {
         if !self.is_cdata.get() {

--- a/crates/oxvg_optimiser/src/jobs/minify_styles.rs
+++ b/crates/oxvg_optimiser/src/jobs/minify_styles.rs
@@ -17,8 +17,8 @@ use oxvg_ast::{
 use oxvg_collections::{
     atom::Atom,
     attribute::{
-        core_attrs::{Class, Id},
         AttrId,
+        core_attrs::{Class, Id},
     },
     is_prefix,
 };
@@ -90,7 +90,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MinifyStyles {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         State::new(self).start_with_context(document, context)?;
@@ -103,7 +103,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_script(document);
@@ -112,17 +112,17 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if is_element!(element, Style) && element.child_nodes_iter().next().is_some() {
             self.style_elements
                 .borrow_mut()
-                .insert(element.id(), element.clone());
+                .insert(element.id(), element);
         } else if has_attribute!(element, Style) {
             self.elements_with_style
                 .borrow_mut()
-                .insert(element.id(), element.clone());
+                .insert(element.id(), element);
         }
 
         if matches!(self.options.usage, RemoveUnused::False) {
@@ -138,7 +138,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
         );
 
         if let Some(id) = get_attribute!(element, Id) {
-            self.ids_usage.borrow_mut().insert(id.clone());
+            self.ids_usage.borrow_mut().insert((*id).clone());
         }
 
         element
@@ -150,7 +150,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn exit_document(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         for style_element in self.style_elements.borrow().values() {

--- a/crates/oxvg_optimiser/src/jobs/mod.rs
+++ b/crates/oxvg_optimiser/src/jobs/mod.rs
@@ -53,7 +53,7 @@ macro_rules! jobs {
             /// Runs each job in the config, returning the number of non-skipped jobs
             fn run_jobs<'input, 'arena>(
                 &self,
-                element: &Element<'input, 'arena>,
+                element: Element<'input, 'arena>,
                 info: &Info<'input, 'arena>
             ) -> Result<usize, JobsError<'input>> {
                 let mut count = 0;
@@ -356,7 +356,7 @@ impl Jobs {
             return Ok(());
         };
 
-        let count = self.run_jobs(&root_element, info)?;
+        let count = self.run_jobs(root_element, info)?;
         log::debug!("completed {count} jobs");
         Ok(())
     }

--- a/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_elems_attrs_to_group.rs
@@ -6,8 +6,8 @@ use oxvg_ast::{
     visitor::{Context, ContextFlags, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::{
-    inheritable::{self, Inheritable},
     Attr, AttrId, AttributeInfo,
+    inheritable::{self, Inheritable},
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MoveElemsAttrsToGroup {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -59,7 +59,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MoveElemsAttrsToGroup {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, G) {
@@ -109,7 +109,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MoveElemsAttrsToGroup {
 }
 
 fn get_common_attributes<'input>(
-    parent: &Element<'input, '_>,
+    parent: Element<'input, '_>,
 ) -> BTreeMap<AttrId<'input>, Attr<'input>> {
     let mut common_attributes: BTreeMap<_, _> = parent
         .first_element_child()

--- a/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/move_group_attrs_to_elems.rs
@@ -6,8 +6,8 @@ use oxvg_ast::{
     visitor::{Context, PrepareOutcome, Visitor},
 };
 use oxvg_collections::attribute::{
-    inheritable::{self, Inheritable},
     AttrId,
+    inheritable::{self, Inheritable},
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MoveGroupAttrsToElems {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -52,7 +52,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for MoveGroupAttrsToElems {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, G) {

--- a/crates/oxvg_optimiser/src/jobs/precheck.rs
+++ b/crates/oxvg_optimiser/src/jobs/precheck.rs
@@ -50,7 +50,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Precheck {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut oxvg_ast::visitor::Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if self.preclean_checks {
@@ -62,7 +62,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Precheck {
 }
 
 impl Precheck {
-    fn check<'input>(element: &Element<'input, '_>) -> Result<(), PrecheckError<'input>> {
+    fn check<'input>(element: Element<'input, '_>) -> Result<(), PrecheckError<'input>> {
         Self::check_for_unsupported_elements(element)?;
         Self::check_for_script_attributes(element)?;
         Self::check_for_conditional_attributes(element)?;
@@ -70,7 +70,7 @@ impl Precheck {
     }
 
     fn check_for_unsupported_elements<'input>(
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
     ) -> Result<(), PrecheckError<'input>> {
         if is_element!(element, Script) {
             Err(PrecheckError::ScriptingNotSupported)
@@ -85,7 +85,7 @@ impl Precheck {
     }
 
     fn check_for_script_attributes<'input>(
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
     ) -> Result<(), PrecheckError<'input>> {
         for attr in element.attributes() {
             if attr
@@ -101,7 +101,7 @@ impl Precheck {
     }
 
     fn check_for_conditional_attributes<'input>(
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
     ) -> Result<(), PrecheckError<'input>> {
         for attr in element.attributes() {
             if attr
@@ -118,14 +118,16 @@ impl Precheck {
     }
 
     fn check_for_external_xlink<'input>(
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
     ) -> Result<(), PrecheckError<'input>> {
         if is_element!(element, A | Image | FontFaceURI | FeImage) {
             return Ok(());
         }
 
         if let Some(xlink_href) = get_attribute!(element, XLinkHref) {
-            return Err(PrecheckError::ReferencesExternalXLink(xlink_href.clone()));
+            return Err(PrecheckError::ReferencesExternalXLink(
+                (*xlink_href).clone(),
+            ));
         }
 
         Ok(())

--- a/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
+++ b/crates/oxvg_optimiser/src/jobs/prefix_ids.rs
@@ -103,7 +103,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for PrefixIds {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if !self.prefix_ids && !self.prefix_class_names {
@@ -115,7 +115,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for PrefixIds {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut prefix_generator = GeneratePrefix::new(context.info, &self.prefix, &self.delim);
@@ -190,7 +190,7 @@ impl<'input> lightningcss::visitor::Visitor<'input> for CssVisitor<'_, '_> {
 impl PrefixIds {
     fn prefix_selectors(
         &self,
-        element: &Element,
+        element: Element,
         prefix_generator: &mut GeneratePrefix,
     ) -> Option<()> {
         if element.is_empty() {

--- a/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attributes_by_selector.rs
@@ -45,7 +45,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveAttributesBySelector {
 
     fn document(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         _context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         for item in &self.0 {

--- a/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_attrs.rs
@@ -130,7 +130,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveAttrs {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut parsed_attrs = Vec::with_capacity(self.attrs.len());

--- a/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_deprecated_attrs.rs
@@ -114,7 +114,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDeprecatedAttrs {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -123,7 +123,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDeprecatedAttrs {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let attributes_in_stylesheet =
@@ -132,11 +132,12 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDeprecatedAttrs {
         // # Special cases
         // Removing deprecated xml:lang is safe when the lang attribute exists.
         if let Some(attr) = element.get_attribute(&AttrId::XmlLang)
-            && has_attribute!(element, Lang) && !attributes_in_stylesheet.contains_qual(attr.name())
-            {
-                drop(attr);
-                element.remove_attribute(&AttrId::XmlLang);
-            }
+            && has_attribute!(element, Lang)
+            && !attributes_in_stylesheet.contains_qual(attr.name())
+        {
+            drop(attr);
+            element.remove_attribute(&AttrId::XmlLang);
+        }
 
         // # General cases
         self.process_attributes(element, &attributes_in_stylesheet);
@@ -146,7 +147,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDeprecatedAttrs {
 }
 
 impl RemoveDeprecatedAttrs {
-    fn process_attributes(&self, element: &Element, attributes_in_stylesheet: &AttrStylesheet) {
+    fn process_attributes(&self, element: Element, attributes_in_stylesheet: &AttrStylesheet) {
         element.attributes().retain(|attr| {
             if attributes_in_stylesheet.contains_qual(attr.name()) {
                 return true;

--- a/crates/oxvg_optimiser/src/jobs/remove_desc.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_desc.rs
@@ -42,7 +42,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDesc {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Desc) {

--- a/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_dimensions.rs
@@ -4,7 +4,7 @@ use oxvg_ast::{
     get_attribute, has_attribute, is_element, remove_attribute, set_attribute,
     visitor::{Context, PrepareOutcome, Visitor},
 };
-use oxvg_collections::attribute::{presentation::LengthPercentage, uncategorised::ViewBox, AttrId};
+use oxvg_collections::attribute::{AttrId, presentation::LengthPercentage, uncategorised::ViewBox};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -40,7 +40,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDimensions {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -52,7 +52,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDimensions {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Svg) {

--- a/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_doctype.rs
@@ -34,7 +34,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveDoctype {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {

--- a/crates/oxvg_optimiser/src/jobs/remove_editors_n_s_data.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_editors_n_s_data.rs
@@ -46,7 +46,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveEditorsNSData {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let uri = element.prefix().ns().uri();

--- a/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_elements_by_attr.rs
@@ -40,15 +40,16 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveElementsByAttr {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), JobsError<'input>> {
         if !self.id.is_empty()
             && let Some(id) = get_attribute!(element, Id)
-                && self.id.iter().any(|i| i == &**id) {
-                    element.remove();
-                    return Ok(());
-                }
+            && self.id.iter().any(|i| i == &**id)
+        {
+            element.remove();
+            return Ok(());
+        }
 
         if !self.class.is_empty() {
             element.class_list().with_iter(|i| {

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_attrs.rs
@@ -34,7 +34,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveEmptyAttrs {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -46,7 +46,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveEmptyAttrs {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         element.attributes().retain(|a| {

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_containers.rs
@@ -37,7 +37,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveEmptyContainers {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -51,7 +51,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveEmptyContainers {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let name = element.qual_name();

--- a/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_empty_text.rs
@@ -47,7 +47,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveEmptyText {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if self.text.unwrap_or(true) && is_element!(element, Text) && element.is_empty() {

--- a/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_hidden_elems.rs
@@ -115,7 +115,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Data<'input, 'arena> {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -124,7 +124,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Data<'input, 'arena> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if element
@@ -134,7 +134,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Data<'input, 'arena> {
         {
             self.non_rendered_nodes
                 .borrow_mut()
-                .insert(HashableElement::new(element.clone()));
+                .insert(HashableElement::new(element));
             context.flags.visit_skip();
             return Ok(());
         }
@@ -152,7 +152,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Data<'input, 'arena> {
             if is_element!(element, Path) {
                 self.non_rendered_nodes
                     .borrow_mut()
-                    .insert(HashableElement::new(element.clone()));
+                    .insert(HashableElement::new(element));
                 context.flags.visit_skip();
                 return Ok(());
             }
@@ -163,8 +163,8 @@ impl<'input, 'arena> Visitor<'input, 'arena> for Data<'input, 'arena> {
 }
 
 impl<'input, 'arena> Data<'input, 'arena> {
-    fn remove_element(&self, element: &Element<'input, 'arena>) {
-        if let Some(parent) = Element::parent_element(element)
+    fn remove_element(&self, element: Element<'input, 'arena>) {
+        if let Some(parent) = Element::parent_element(&element)
             && is_element!(parent, Defs)
         {
             if let Some(NonWhitespace(id)) = get_attribute!(element, Id).as_deref() {
@@ -180,12 +180,12 @@ impl<'input, 'arena> Data<'input, 'arena> {
         element.remove();
     }
 
-    fn ref_element(&self, element: &Element<'input, 'arena>) {
+    fn ref_element(&self, element: Element<'input, 'arena>) {
         match element.qual_name().unaliased() {
             ElementId::Defs => {
                 self.all_defs
                     .borrow_mut()
-                    .insert(HashableElement::new(element.clone()));
+                    .insert(HashableElement::new(element));
             }
             ElementId::Use => {
                 for attr in element.attributes() {
@@ -197,9 +197,9 @@ impl<'input, 'arena> Data<'input, 'arena> {
                     let mut references_by_id = self.references_by_id.borrow_mut();
                     let refs = references_by_id.get_mut(id);
                     match refs {
-                        Some(refs) => refs.push(element.clone()),
+                        Some(refs) => refs.push(element),
                         None => {
-                            references_by_id.insert(id.into(), vec![element.clone()]);
+                            references_by_id.insert(id.into(), vec![element]);
                         }
                     }
                 }
@@ -214,12 +214,11 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveHiddenElems {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         log::debug!("collecting data");
         context.query_has_script(document);
-        let document = &mut document.clone();
         let mut data = Data {
             opacity_zero: self.opacity_zero.unwrap_or(true),
             ..Data::default()
@@ -240,7 +239,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -249,7 +248,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let computed_styles = ComputedStyles::default()
@@ -288,7 +287,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 
     fn exit_document(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         for id in &*self.data.removed_def_ids.borrow() {
@@ -305,7 +304,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
         );
         if !deoptimized {
             for non_rendered_node in &*self.data.non_rendered_nodes.borrow() {
-                if self.can_remove_non_rendering_node(non_rendered_node) {
+                if self.can_remove_non_rendering_node(**non_rendered_node) {
                     log::debug!("RemoveHiddenElems: remove non-rendered node");
                     non_rendered_node.remove();
                 }
@@ -324,7 +323,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input, 'arena> {
 }
 
 impl<'input, 'arena> State<'_, 'input, 'arena> {
-    fn can_remove_non_rendering_node(&self, element: &Element<'input, 'arena>) -> bool {
+    fn can_remove_non_rendering_node(&self, element: Element<'input, 'arena>) -> bool {
         if let Some(id) = get_attribute!(element, Id)
             && self.data.all_references.borrow().contains(&**id)
         {
@@ -332,12 +331,12 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
         }
         element
             .children_iter()
-            .all(|e| self.can_remove_non_rendering_node(&e))
+            .all(|e| self.can_remove_non_rendering_node(e))
     }
 
     fn is_hidden_style(
         &self,
-        element: &Element,
+        element: Element,
         computed_styles: &ComputedStyles,
         context: &mut Context,
     ) -> bool {
@@ -383,7 +382,7 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
         is_hidden
     }
 
-    fn is_hidden_ellipse(&self, element: &Element<'input, 'arena>) -> bool {
+    fn is_hidden_ellipse(&self, element: Element<'input, 'arena>) -> bool {
         if is_element!(element, Circle)
             && element.is_empty()
             && self.options.circle_r_zero.unwrap_or(true)
@@ -419,7 +418,7 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
         false
     }
 
-    fn is_hidden_rect(&self, element: &Element<'input, 'arena>) -> bool {
+    fn is_hidden_rect(&self, element: Element<'input, 'arena>) -> bool {
         if is_element!(element, Rect) && element.is_empty() {
             if self.options.rect_width_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
@@ -439,7 +438,7 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
         false
     }
 
-    fn is_hidden_pattern(&self, element: &Element<'input, 'arena>) -> bool {
+    fn is_hidden_pattern(&self, element: Element<'input, 'arena>) -> bool {
         if is_element!(element, Pattern) {
             if self.options.pattern_width_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
@@ -459,7 +458,7 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
         false
     }
 
-    fn is_hidden_image(&self, element: &Element<'input, 'arena>) -> bool {
+    fn is_hidden_image(&self, element: Element<'input, 'arena>) -> bool {
         if is_element!(element, Image) {
             if self.options.image_width_zero.unwrap_or(true)
                 && let Some(LengthPercentage(DimensionPercentage::Dimension(length))) =
@@ -481,7 +480,7 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
 
     fn is_hidden_path(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         computed_styles: &ComputedStyles<'input>,
     ) -> bool {
         if self.options.path_empty_d.unwrap_or(true) && is_element!(element, Path) {
@@ -496,7 +495,7 @@ impl<'input, 'arena> State<'_, 'input, 'arena> {
         false
     }
 
-    fn is_hidden_poly(&self, element: &Element<'input, 'arena>) -> bool {
+    fn is_hidden_poly(&self, element: Element<'input, 'arena>) -> bool {
         if self.options.polyline_empty_points.unwrap_or(true)
             && is_element!(element, Polyline)
             && !has_attribute!(element, Points)

--- a/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_metadata.rs
@@ -34,7 +34,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveMetadata {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -46,7 +46,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveMetadata {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if is_element!(element, Metadata) {

--- a/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_non_inheritable_group_attrs.rs
@@ -38,7 +38,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveNonInheritableGroupAttrs 
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -50,7 +50,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveNonInheritableGroupAttrs 
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, G) {

--- a/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_off_canvas_paths.rs
@@ -49,7 +49,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveOffCanvasPaths {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
@@ -67,7 +67,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if element.is_root() && is_element!(element, Svg) {
@@ -138,7 +138,7 @@ enum GatherViewboxDataError {
     MissingViewbox,
 }
 
-fn gather(element: &Element) -> Result<ViewBox, GatherViewboxDataError> {
+fn gather(element: Element) -> Result<ViewBox, GatherViewboxDataError> {
     let width = get_attribute!(element, WidthSvg);
     let height = get_attribute!(element, HeightSvg);
     let Some(viewbox) = get_attribute!(element, ViewBox) else {
@@ -156,13 +156,13 @@ fn gather(element: &Element) -> Result<ViewBox, GatherViewboxDataError> {
                     height: height
                         .to_px()
                         .ok_or(GatherViewboxDataError::ParseFloatError)?,
-                })
+                });
             }
             _ => return Err(GatherViewboxDataError::MissingViewbox),
         }
     };
 
-    Ok(viewbox.clone())
+    Ok((*viewbox).clone())
 }
 
 #[test]

--- a/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_raster_images.rs
@@ -34,7 +34,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveRasterImages {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -46,7 +46,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveRasterImages {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Image) {

--- a/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_scripts.rs
@@ -39,7 +39,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveScripts {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -51,7 +51,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveScripts {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if is_element!(element, Script) {
@@ -72,7 +72,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveScripts {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, A) {

--- a/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_style_element.rs
@@ -34,7 +34,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveStyleElement {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -46,7 +46,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveStyleElement {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if is_element!(element, Style) {

--- a/crates/oxvg_optimiser/src/jobs/remove_title.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_title.rs
@@ -37,7 +37,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveTitle {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -49,7 +49,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveTitle {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if is_element!(element, Title) {

--- a/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unknowns_and_defaults.rs
@@ -99,7 +99,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUnknownsAndDefaults {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -144,7 +144,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUnknownsAndDefaults {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if context.flags.contains(ContextFlags::within_foreign_object) {
@@ -167,7 +167,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUnknownsAndDefaults {
 }
 
 impl RemoveUnknownsAndDefaults {
-    fn remove_unknown_content(&self, element: &Element) {
+    fn remove_unknown_content(&self, element: Element) {
         if !self.unknown_content {
             return;
         }
@@ -178,7 +178,7 @@ impl RemoveUnknownsAndDefaults {
             element.remove();
         }
 
-        let Some(parent) = Element::parent_element(element) else {
+        let Some(parent) = Element::parent_element(&element) else {
             return;
         };
         if parent.node_type() == node::Type::Document {
@@ -194,7 +194,7 @@ impl RemoveUnknownsAndDefaults {
 
     fn remove_unknown_and_default_attrs<'input>(
         &self,
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         inherited_styles: &ComputedStyles<'input>,
     ) {
         let element_name = element.qual_name();

--- a/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_unused_n_s.rs
@@ -46,7 +46,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUnusedNS {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
@@ -61,12 +61,12 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input> {
 
     fn document(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         _content: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut unused_namespaces = self.unused_namespaces.take();
         document.children_iter().for_each(|e| {
-            root_element(&e, &mut unused_namespaces);
+            root_element(e, &mut unused_namespaces);
         });
         self.unused_namespaces.set(unused_namespaces);
         Ok(())
@@ -74,7 +74,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut unused_namespaces = self.unused_namespaces.take();
@@ -99,12 +99,12 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input> {
 
     fn exit_document(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         _context: &Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut unused_namespaces = self.unused_namespaces.take();
         document.children_iter().for_each(|e| {
-            exit_root_element(&e, &mut unused_namespaces);
+            exit_root_element(e, &mut unused_namespaces);
         });
         self.unused_namespaces.set(unused_namespaces);
         Ok(())
@@ -112,7 +112,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input> {
 }
 
 fn root_element<'input>(
-    element: &Element<'input, '_>,
+    element: Element<'input, '_>,
     unused_namespaces: &mut HashSet<Atom<'input>>,
 ) {
     if !is_element!(element, Svg) {
@@ -134,7 +134,7 @@ fn root_element<'input>(
     }
 }
 
-fn exit_root_element(element: &Element, unused_namespaces: &mut HashSet<Atom>) {
+fn exit_root_element(element: Element, unused_namespaces: &mut HashSet<Atom>) {
     if !is_element!(element, Svg) {
         return;
     }

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_defs.rs
@@ -40,7 +40,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUselessDefs {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -52,7 +52,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUselessDefs {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if has_attribute!(element, Id | Class) {
@@ -80,14 +80,14 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUselessDefs {
 }
 
 fn collect_useful_nodes<'input, 'arena>(
-    element: &Element<'input, 'arena>,
+    element: Element<'input, 'arena>,
     useful_nodes: &mut Vec<Element<'input, 'arena>>,
 ) {
     element.children_iter().for_each(|child| {
         if is_element!(child, Style) || has_attribute!(child, Id | Class) {
             useful_nodes.push(child);
         } else {
-            collect_useful_nodes(&child, useful_nodes);
+            collect_useful_nodes(child, useful_nodes);
         }
     });
 }

--- a/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_useless_stroke_and_fill.rs
@@ -58,7 +58,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveUselessStrokeAndFill {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         State {
@@ -75,7 +75,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_> {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_script(document);
@@ -93,7 +93,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if self.id_rc_byte.get().is_some() {
@@ -122,7 +122,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_> {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if self.id_rc_byte.get().is_some_and(|b| b == element.id()) {
@@ -137,7 +137,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_> {
 impl State<'_> {
     fn remove_stroke<'input>(
         &self,
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         computed_styles: &ComputedStyles<'input>,
     ) {
         if !self.options.stroke {
@@ -218,7 +218,7 @@ impl State<'_> {
 
     fn remove_fill<'input>(
         &self,
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         computed_styles: &ComputedStyles<'input>,
     ) {
         if !self.options.fill {

--- a/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_view_box.rs
@@ -39,7 +39,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveViewBox {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -51,7 +51,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveViewBox {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Pattern | Svg | Symbol) {

--- a/crates/oxvg_optimiser/src/jobs/remove_x_m_l_n_s.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_x_m_l_n_s.rs
@@ -38,7 +38,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveXMLNS {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -50,7 +50,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveXMLNS {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if is_element!(element, Svg) {

--- a/crates/oxvg_optimiser/src/jobs/remove_x_m_l_proc_inst.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_x_m_l_proc_inst.rs
@@ -35,7 +35,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveXMLProcInst {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {

--- a/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
+++ b/crates/oxvg_optimiser/src/jobs/remove_xlink.rs
@@ -7,10 +7,10 @@ use oxvg_ast::{
 };
 use oxvg_collections::{
     atom::Atom,
-    attribute::{uncategorised::Target, xlink::XLinkShow, Attr, AttrId},
+    attribute::{Attr, AttrId, uncategorised::Target, xlink::XLinkShow},
     element::{ElementId, ElementInfo},
     is_prefix,
-    name::{QualName, NS},
+    name::{NS, QualName},
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -57,7 +57,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for RemoveXlink {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         State {
@@ -76,7 +76,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let mut xlink_prefix_stack = self.xlink_prefix_stack.borrow_mut();
@@ -98,9 +98,10 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input> {
                 overridden_prefix_stack.push(false);
                 used_in_legacy_element_stack.push(false);
             } else if xlink_prefix_stack.last() == Some(local)
-                && let Some(last) = overridden_prefix_stack.last_mut() {
-                    *last = true;
-                }
+                && let Some(last) = overridden_prefix_stack.last_mut()
+            {
+                *last = true;
+            }
         }
         element.attributes().retain(|attr| {
             !is_attribute!(attr, XLinkActuate | XLinkArcrole | XLinkRole | XLinkType)
@@ -118,7 +119,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input> {
 
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         element.attributes().retain(|attr| {
@@ -156,7 +157,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'_, 'input> {
 
 impl<'input> State<'_, 'input> {
     /// Replaces `xlink:show` with `target` when possible
-    fn handle_show(element: &Element<'input, '_>) {
+    fn handle_show(element: Element<'input, '_>) {
         if has_attribute!(element, Target) {
             remove_attribute!(element, XLinkShow);
             return;
@@ -171,14 +172,15 @@ impl<'input> State<'_, 'input> {
         };
         drop(show);
         if let Some(target) = target
-            && target != Target::default() {
-                set_attribute!(element, Target(target));
-                remove_attribute!(element, XLinkShow);
-            }
+            && target != Target::default()
+        {
+            set_attribute!(element, Target(target));
+            remove_attribute!(element, XLinkShow);
+        }
     }
 
     fn handle_title<'arena>(
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &Context<'input, 'arena, '_>,
     ) {
         if element
@@ -200,7 +202,7 @@ impl<'input> State<'_, 'input> {
     }
 
     fn handle_href(
-        element: &Element<'input, '_>,
+        element: Element<'input, '_>,
         used_in_legacy_element: &mut [bool],
         include_legacy: bool,
     ) {

--- a/crates/oxvg_optimiser/src/jobs/reuse_paths.rs
+++ b/crates/oxvg_optimiser/src/jobs/reuse_paths.rs
@@ -9,12 +9,13 @@ use oxvg_ast::{
 use oxvg_collections::{
     atom::Atom,
     attribute::{
+        Attr, AttrId,
         core_attrs::{NonWhitespace, Url},
         inheritable::Inheritable,
-        path, Attr, AttrId,
+        path,
     },
     element::ElementId,
-    name::{Prefix, QualName, NS},
+    name::{NS, Prefix, QualName},
 };
 use oxvg_path::Path;
 use parcel_selectors::parser::Component;
@@ -55,7 +56,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for ReusePaths {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         if self.0 {
@@ -70,7 +71,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 
     fn prepare(
         &self,
-        document: &Element<'input, 'arena>,
+        document: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         context.query_has_stylesheet(document);
@@ -79,7 +80,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         match element.qual_name().unaliased() {
@@ -90,7 +91,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
                         .parent_element()
                         .is_some_and(|parent| is_element!(parent, Svg))
                 {
-                    self.defs.replace(Some(element.clone()));
+                    self.defs.replace(Some(element));
                 }
             }
             ElementId::Use => {
@@ -113,7 +114,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
     #[allow(clippy::too_many_lines)]
     fn exit_element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !element.is_root() && !is_element!(element, Svg) {
@@ -127,12 +128,12 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
         let document = context.root.as_document();
         let defs = self.defs.borrow();
         let defs = if let Some(defs) = &*defs {
-            defs.clone()
+            *defs
         } else {
             drop(defs);
             let defs = document.create_element(ElementId::Defs, &context.info.allocator);
             element.insert(0, &defs);
-            self.defs.replace(Some(defs.clone()));
+            self.defs.replace(Some(defs));
             defs
         };
 
@@ -198,9 +199,10 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
                                 let mut href = get_attribute_mut!(child, Href)
                                     .or_else(|| get_attribute_mut!(child, XLinkHref));
                                 if let Some(url) = href.as_deref_mut()
-                                    && url.as_str() == old_url {
-                                        *url = new_id.clone();
-                                    }
+                                    && url.as_str() == old_url
+                                {
+                                    *url = new_id.clone();
+                                }
                             }
                         }
                     }
@@ -226,7 +228,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for State<'input, 'arena> {
 }
 
 impl<'input, 'arena> State<'input, 'arena> {
-    fn add_path(&self, element: &Element<'input, 'arena>) {
+    fn add_path(&self, element: Element<'input, 'arena>) {
         let Some(path::Path(path, _)) = get_attribute!(element, D).as_deref().cloned() else {
             return;
         };
@@ -236,8 +238,8 @@ impl<'input, 'arena> State<'input, 'arena> {
         let mut paths = self.paths.borrow_mut();
         let list = paths.iter_mut().find(|(k, _)| k == &key);
         match list {
-            Some((_, list)) => list.push(element.clone()),
-            None => paths.push((key, vec![element.clone()])),
+            Some((_, list)) => list.push(element),
+            None => paths.push((key, vec![element])),
         }
     }
 }

--- a/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_attrs.rs
@@ -62,7 +62,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for SortAttrs {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         let xmlns_order = self.xmlns_order.is_none() || self.xmlns_order == Some(XMLNSOrder::Front);

--- a/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
+++ b/crates/oxvg_optimiser/src/jobs/sort_defs_children.rs
@@ -39,7 +39,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for SortDefsChildren {
 
     fn prepare(
         &self,
-        _document: &Element<'input, 'arena>,
+        _document: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<PrepareOutcome, Self::Error> {
         Ok(if self.0 {
@@ -51,7 +51,7 @@ impl<'input, 'arena> Visitor<'input, 'arena> for SortDefsChildren {
 
     fn element(
         &self,
-        element: &Element<'input, 'arena>,
+        element: Element<'input, 'arena>,
         _context: &mut Context<'input, 'arena, '_>,
     ) -> Result<(), Self::Error> {
         if !is_element!(element, Defs) {
@@ -73,12 +73,13 @@ impl<'input, 'arena> Visitor<'input, 'arena> for SortDefsChildren {
             let a_frequency = frequencies.get(a_name);
             let b_frequency = frequencies.get(b_name);
             if let Some(a_frequency) = a_frequency
-                && let Some(b_frequency) = b_frequency {
-                    let frequency_ord = b_frequency.cmp(a_frequency);
-                    if frequency_ord != Ordering::Equal {
-                        return frequency_ord;
-                    }
+                && let Some(b_frequency) = b_frequency
+            {
+                let frequency_ord = b_frequency.cmp(a_frequency);
+                if frequency_ord != Ordering::Equal {
+                    return frequency_ord;
                 }
+            }
             let len_ord = b_name.len().cmp(&a_name.len());
             if len_ord != Ordering::Equal {
                 return len_ord;

--- a/packages/napi/src/lib.rs
+++ b/packages/napi/src/lib.rs
@@ -332,9 +332,13 @@ impl Actor {
   }
 
   /// Removes OXVG state from the document
+  ///
+  /// # Errors
+  ///
+  /// If the state fails to update
   #[napi]
-  pub fn forget(&mut self) {
-    self.actor.forget();
+  pub fn forget(&mut self) -> napi::Result<()> {
+    self.actor.forget().map_err(generic_error)
   }
 
   /// Updates the state of the actor to point to the elements matching the given selector.
@@ -365,9 +369,13 @@ impl Actor {
   }
 
   /// Updates the state of the actor to deselected any selected nodes.
+  ///
+  /// # Errors
+  ///
+  /// If the state fails to update
   #[napi]
-  pub fn deselect(&mut self) {
-    self.actor.deselect();
+  pub fn deselect(&mut self) -> napi::Result<()> {
+    self.actor.deselect().map_err(generic_error)
   }
 
   /// Returns the actor's updated document as a string

--- a/packages/napi/src/lib.rs
+++ b/packages/napi/src/lib.rs
@@ -331,6 +331,16 @@ impl Actor {
     self.actor.skew_y(angle as f32).map_err(generic_error)
   }
 
+  /// Creates a new SVG element and inserts it into the current selection.
+  ///
+  /// # Errors
+  ///
+  /// When root element is missing.
+  #[napi]
+  pub fn insert(&mut self, qual_name: String) -> napi::Result<()> {
+    self.actor.insert(&qual_name.into()).map_err(generic_error)
+  }
+
   /// Removes OXVG state from the document
   ///
   /// # Errors

--- a/packages/wasm/src/lib.rs
+++ b/packages/wasm/src/lib.rs
@@ -470,6 +470,16 @@ impl Actor {
         self.actor.skew_y(angle)
     }
 
+    /// Creates a new SVG element and inserts it into the current selection.
+    ///
+    /// # Errors
+    ///
+    /// When root element is missing.
+    #[wasm_bindgen]
+    pub fn insert(&mut self, qual_name: &str) -> Result<(), Error> {
+        self.actor.insert(&qual_name.to_string().into())
+    }
+
     /// Removes OXVG state from the document
     ///
     /// # Errors

--- a/packages/wasm/src/lib.rs
+++ b/packages/wasm/src/lib.rs
@@ -471,9 +471,13 @@ impl Actor {
     }
 
     /// Removes OXVG state from the document
+    ///
+    /// # Errors
+    ///
+    /// If the state fails to update
     #[wasm_bindgen]
-    pub fn forget(&mut self) {
-        self.actor.forget();
+    pub fn forget(&mut self) -> Result<(), Error> {
+        self.actor.forget()
     }
 
     /// Updates the state of the actor to point to the elements matching the given selector.
@@ -503,9 +507,13 @@ impl Actor {
     }
 
     /// Updates the state of the actor to deselected any selected nodes.
+    ///
+    /// # Errors
+    ///
+    /// If the state fails to update
     #[wasm_bindgen]
-    pub fn deselect(&mut self) {
-        self.actor.deselect();
+    pub fn deselect(&mut self) -> Result<(), Error> {
+        self.actor.deselect()
     }
 
     /// Returns the actor's updated document as a string


### PR DESCRIPTION
## Description

Adds `-insert` action. Includes fixes to improve actions correctness.

## How Has This Been Tested?

- Unit tests

## Types of changes
### Fixes

- Fix allocator reorder

### Features

- Adds insert action
- Implement `Default` and `From` for `ListOf`

### Breaking changes

- Implement `Copy` for `Element`, update usage

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [x] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
