### PR TITLE
chore: Exclude debug formatting from panics in release builds

### DIFF
--- a/crates/oxvg_ast/src/attribute.rs
+++ b/crates/oxvg_ast/src/attribute.rs
@@ -76,7 +76,13 @@ macro_rules! get_attribute {
                 std::cell::Ref::filter_map(attr, |attr| match attr.unaliased() {
                     oxvg_collections::attribute::Attr::$attr(inner) => Some(inner),
                     oxvg_collections::attribute::Attr::Unparsed { .. } => None,
-                    _ => unreachable!("{attr:?} did not match {}", stringify!($attr)),
+                    _ => {
+                      // Don't include debug formatting in release builds.
+                      #[cfg(debug_assertions)]
+                      unreachable!("{attr:?} did not match {}", stringify!($attr));
+                      #[cfg(not(debug_assertions))]
+                      unreachable!("attribute did not match {}", stringify!($attr));
+                    },
                 }).ok()
             })
     };

--- a/crates/oxvg_ast/src/style.rs
+++ b/crates/oxvg_ast/src/style.rs
@@ -34,7 +34,13 @@ macro_rules! get_computed_style {
                 | oxvg_collections::attribute::Attr::CSSUnknown { .. },
                 _,
             )) => $crate::style::ComputedStyle::Unparsed,
-            Some(attr) => unreachable!("{attr:?}"),
+            Some(attr) => {
+                // Don't include debug formatting in release builds.
+                #[cfg(debug_assertions)]
+                unreachable!("{attr:?}");
+                #[cfg(not(debug_assertions))]
+                unreachable!("computed style did not match");
+            }
             None => $crate::style::ComputedStyle::None,
         }
     };


### PR DESCRIPTION
## Description

Reduces binary size by excluding debug formatting from panic messages in release builds. For Parcel, this reduced binary size by ~670KB by excluding unused Debug implementations for the entire AST.

## Motivation and Context
To reduce binary size as described above.

## How Has This Been Tested?
Tested locally in parcel. Ran unit tests.

## Types of changes
### Fixes
* Reduce binary size

### Features
<!-- List non-breaking changes which add functionality) -->

### Breaking changes
<!-- List fixes or features that would cause existing functionality to change -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <!-- Ensure `cargo check` runs without warning -->
- [ ] My change requires a change to the documentation. <!-- Aim for 100% rustdoc coverage and doctests where appropriate -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- Aim for high feature coverage in unit tests -->
- [x] All new and existing tests passed.
